### PR TITLE
Update jsonschema dependency to >=4.15.0 (replacing >3)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     requests >=2.20, <3
     ruamel.yaml >=0.16.0
     pykwalify >=1.6
-    jsonschema >=3.0, <4
+    jsonschema >=4.0, <5
 
 [options.data_files]
 # This section requires setuptools>=40.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     requests >=2.20, <3
     ruamel.yaml >=0.16.0
     pykwalify >=1.6
-    jsonschema >=4.0, <5
+    jsonschema >=4.15.0, <5
 
 [options.data_files]
 # This section requires setuptools>=40.6.0


### PR DESCRIPTION
I'm in the process of using cffconvert to analyze validation errors in a dataset of CFF files. 

`jsonschema` > 4 introduces a property `jsonschema.exceptions.ValidationError`.`json_path` that the currently bundled dependency (3.2.0) doesn't have. This property makes it really easy to find the offending field. I'd therefore suggest to bump the `jsonschema` version to `>4.15.0 <5` as per this PR. (4.15.0 is known to work.)

All tests pass locally.