### PR TITLE
zenodo related identifiers

### DIFF
--- a/src/cffconvert/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/cff_1_x_x/zenodo.py
@@ -11,6 +11,7 @@ class ZenodoObjectShared:
         "keywords",
         "license",
         "publication_date",
+        "related_identifiers",
         "title",
         "upload_type",
         "version"
@@ -24,6 +25,7 @@ class ZenodoObjectShared:
         self.keywords = None
         self.license = None
         self.publication_date = None
+        self.related_identifiers = None
         self.title = None
         self.upload_type = None
         self.version = None
@@ -41,6 +43,7 @@ class ZenodoObjectShared:
             "keywords": self.keywords,
             "license": self.license,
             "publication_date": self.publication_date,
+            "related_identifiers": self.related_identifiers,
             "title": self.title,
             "upload_type": self.upload_type,
             "version": self.version
@@ -49,13 +52,14 @@ class ZenodoObjectShared:
         return json.dumps(dict(filtered), sort_keys=sort_keys, indent=indent, ensure_ascii=False) + "\n"
 
     def add_all(self):
-        self.add_creators()          \
-            .add_description()       \
-            .add_keywords()          \
-            .add_license()           \
-            .add_publication_date()  \
-            .add_title()             \
-            .add_upload_type()       \
+        self.add_creators()            \
+            .add_description()         \
+            .add_keywords()            \
+            .add_license()             \
+            .add_publication_date()    \
+            .add_related_identifiers() \
+            .add_title()               \
+            .add_upload_type()         \
             .add_version()
         return self
 
@@ -81,6 +85,18 @@ class ZenodoObjectShared:
     @abstractmethod
     def add_publication_date(self):
         pass
+
+    def add_related_identifiers(self):
+        if "identifiers" in self.cffobj.keys():
+            related_identifiers = list()
+            for identifier in self.cffobj.get("identifiers"):
+                related_identifiers.append({
+                    "scheme": identifier.get("type"),
+                    "identifier": identifier.get("value"),
+                    "relation": "isSupplementTo"
+                })
+            self.related_identifiers = related_identifiers
+        return self
 
     def add_title(self):
         if "title" in self.cffobj.keys():

--- a/src/cffconvert/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/cff_1_x_x/zenodo.py
@@ -93,7 +93,7 @@ class ZenodoObjectShared:
                     deduplication_key: {
                         "scheme": identifier.get("type"),
                         "identifier": deduplication_key,
-                        "relation": "isSupplementTo"
+                        "relation": "isSupplementedBy"
                     }
                 })
         if "doi" in self.cffobj:
@@ -102,7 +102,7 @@ class ZenodoObjectShared:
                 deduplication_key: {
                     "scheme": "doi",
                     "identifier": deduplication_key,
-                    "relation": "isSupplementTo"
+                    "relation": "isSupplementedBy"
                 }
             })
         for cffkey in ["repository", "repository-artifact", "repository-code", "url"]:
@@ -112,7 +112,7 @@ class ZenodoObjectShared:
                     deduplication_key: {
                         "scheme": "url",
                         "identifier": deduplication_key,
-                        "relation": "isSupplementTo"
+                        "relation": "isSupplementedBy"
                     }
                 })
         self.related_identifiers = [v for k, v in related_identifiers.items()] if len(related_identifiers) > 0 else None

--- a/src/cffconvert/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/cff_1_x_x/zenodo.py
@@ -68,18 +68,16 @@ class ZenodoObjectShared:
         pass
 
     def add_description(self):
-        if "abstract" in self.cffobj.keys():
-            self.description = self.cffobj["abstract"]
+        self.description = self.cffobj.get("abstract")
         return self
 
     def add_keywords(self):
-        if "keywords" in self.cffobj.keys():
-            self.keywords = self.cffobj["keywords"]
+        self.keywords = self.cffobj.get("keywords")
         return self
 
     def add_license(self):
-        if "license" in self.cffobj.keys():
-            self.license = {"id": self.cffobj["license"]}
+        if "license" in self.cffobj:
+            self.license = {"id": self.cffobj.get("license")}
         return self
 
     @abstractmethod
@@ -87,25 +85,22 @@ class ZenodoObjectShared:
         pass
 
     def add_related_identifiers(self):
-        if "identifiers" in self.cffobj.keys():
-            related_identifiers = list()
-            for identifier in self.cffobj.get("identifiers"):
-                related_identifiers.append({
-                    "scheme": identifier.get("type"),
-                    "identifier": identifier.get("value"),
-                    "relation": "isSupplementTo"
-                })
-            self.related_identifiers = related_identifiers
+        related_identifiers = list()
+        for identifier in self.cffobj.get("identifiers", list()):
+            related_identifiers.append({
+                "scheme": identifier.get("type"),
+                "identifier": identifier.get("value"),
+                "relation": "isSupplementTo"
+            })
+        self.related_identifiers = related_identifiers if len(related_identifiers) > 0 else None
         return self
 
     def add_title(self):
-        if "title" in self.cffobj.keys():
-            self.title = self.cffobj["title"]
+        self.title = self.cffobj.get("title")
         return self
 
     def add_version(self):
-        if "version" in self.cffobj.keys():
-            self.version = self.cffobj["version"]
+        self.version = self.cffobj.get("version")
         return self
 
     def as_string(self):

--- a/src/cffconvert/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/cff_1_x_x/zenodo.py
@@ -85,28 +85,37 @@ class ZenodoObjectShared:
         pass
 
     def add_related_identifiers(self):
-        related_identifiers = []
+        related_identifiers = {}
         for identifier in self.cffobj.get("identifiers", []):
             if identifier.get("type") != "other":
-                related_identifiers.append({
-                    "scheme": identifier.get("type"),
-                    "identifier": identifier.get("value"),
-                    "relation": "isSupplementTo"
+                deduplication_key = identifier.get("value")
+                related_identifiers.update({
+                    deduplication_key: {
+                        "scheme": identifier.get("type"),
+                        "identifier": deduplication_key,
+                        "relation": "isSupplementTo"
+                    }
                 })
         if "doi" in self.cffobj:
-            related_identifiers.append({
-                "scheme": "doi",
-                "identifier": self.cffobj.get("doi"),
-                "relation": "isSupplementTo"
-            })
-        for key in ["repository", "repository-artifact", "repository-code", "url"]:
-            if key in self.cffobj:
-                related_identifiers.append({
-                    "scheme": "url",
-                    "identifier": self.cffobj.get(key),
+            deduplication_key = self.cffobj.get("doi")
+            related_identifiers.update({
+                deduplication_key: {
+                    "scheme": "doi",
+                    "identifier": deduplication_key,
                     "relation": "isSupplementTo"
+                }
+            })
+        for cffkey in ["repository", "repository-artifact", "repository-code", "url"]:
+            if cffkey in self.cffobj:
+                deduplication_key = self.cffobj.get(cffkey)
+                related_identifiers.update({
+                    deduplication_key: {
+                        "scheme": "url",
+                        "identifier": deduplication_key,
+                        "relation": "isSupplementTo"
+                    }
                 })
-        self.related_identifiers = related_identifiers if len(related_identifiers) > 0 else None
+        self.related_identifiers = [v for k, v in related_identifiers.items()] if len(related_identifiers) > 0 else None
         return self
 
     def add_title(self):

--- a/src/cffconvert/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/cff_1_x_x/zenodo.py
@@ -87,11 +87,19 @@ class ZenodoObjectShared:
     def add_related_identifiers(self):
         related_identifiers = list()
         for identifier in self.cffobj.get("identifiers", list()):
-            related_identifiers.append({
-                "scheme": identifier.get("type"),
-                "identifier": identifier.get("value"),
-                "relation": "isSupplementTo"
-            })
+            if identifier.get("type") != "other":
+                related_identifiers.append({
+                    "scheme": identifier.get("type"),
+                    "identifier": identifier.get("value"),
+                    "relation": "isSupplementTo"
+                })
+        for key in ["repository", "repository-artifact", "repository-code", "url"]:
+            if key in self.cffobj:
+                related_identifiers.append({
+                    "scheme": "url",
+                    "identifier": self.cffobj.get(key),
+                    "relation": "isSupplementTo"
+                })
         self.related_identifiers = related_identifiers if len(related_identifiers) > 0 else None
         return self
 

--- a/src/cffconvert/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/cff_1_x_x/zenodo.py
@@ -85,8 +85,8 @@ class ZenodoObjectShared:
         pass
 
     def add_related_identifiers(self):
-        related_identifiers = list()
-        for identifier in self.cffobj.get("identifiers", list()):
+        related_identifiers = []
+        for identifier in self.cffobj.get("identifiers", []):
             if identifier.get("type") != "other":
                 related_identifiers.append({
                     "scheme": identifier.get("type"),

--- a/src/cffconvert/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/cff_1_x_x/zenodo.py
@@ -93,6 +93,12 @@ class ZenodoObjectShared:
                     "identifier": identifier.get("value"),
                     "relation": "isSupplementTo"
                 })
+        if "doi" in self.cffobj:
+            related_identifiers.append({
+                "scheme": "doi",
+                "identifier": self.cffobj.get("doi"),
+                "relation": "isSupplementTo"
+            })
         for key in ["repository", "repository-artifact", "repository-code", "url"]:
             if key in self.cffobj:
                 related_identifiers.append({

--- a/tests/cff_1_0_3/a/.zenodo.json
+++ b/tests/cff_1_0_3/a/.zenodo.json
@@ -22,12 +22,12 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_0_3/a/.zenodo.json
+++ b/tests/cff_1_0_3/a/.zenodo.json
@@ -19,6 +19,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_0_3/a/.zenodo.json
+++ b/tests/cff_1_0_3/a/.zenodo.json
@@ -21,6 +21,11 @@
   "publication_date": "2018-01-16",
   "related_identifiers": [
     {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_0_3/a/test_zenodo_object.py
+++ b/tests/cff_1_0_3/a/test_zenodo_object.py
@@ -49,11 +49,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_0_3/a/test_zenodo_object.py
+++ b/tests/cff_1_0_3/a/test_zenodo_object.py
@@ -46,6 +46,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_0_3/b/test_zenodo_object.py
+++ b/tests/cff_1_0_3/b/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == "1999-12-31"
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'example title'
 

--- a/tests/cff_1_0_3/c/.zenodo.json
+++ b/tests/cff_1_0_3/c/.zenodo.json
@@ -23,12 +23,12 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1003346",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/NLeSC/spot",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_0_3/c/.zenodo.json
+++ b/tests/cff_1_0_3/c/.zenodo.json
@@ -22,6 +22,11 @@
   "publication_date": "2017-10-07",
   "related_identifiers": [
     {
+      "identifier": "10.5281/zenodo.1003346",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/NLeSC/spot",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_0_3/c/.zenodo.json
+++ b/tests/cff_1_0_3/c/.zenodo.json
@@ -20,6 +20,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2017-10-07",
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/NLeSC/spot",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "spot",
   "upload_type": "software",
   "version": "0.1.0"

--- a/tests/cff_1_0_3/c/test_zenodo_object.py
+++ b/tests/cff_1_0_3/c/test_zenodo_object.py
@@ -55,11 +55,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1003346",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/NLeSC/spot",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_0_3/c/test_zenodo_object.py
+++ b/tests/cff_1_0_3/c/test_zenodo_object.py
@@ -52,6 +52,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2017-10-07'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1003346",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/NLeSC/spot",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'spot'
 

--- a/tests/cff_1_0_3/d/.zenodo.json
+++ b/tests/cff_1_0_3/d/.zenodo.json
@@ -28,6 +28,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-07-25",
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.1"

--- a/tests/cff_1_0_3/d/.zenodo.json
+++ b/tests/cff_1_0_3/d/.zenodo.json
@@ -31,12 +31,12 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_0_3/d/.zenodo.json
+++ b/tests/cff_1_0_3/d/.zenodo.json
@@ -30,6 +30,11 @@
   "publication_date": "2018-07-25",
   "related_identifiers": [
     {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_0_3/d/test_zenodo_object.py
+++ b/tests/cff_1_0_3/d/test_zenodo_object.py
@@ -58,11 +58,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_0_3/d/test_zenodo_object.py
+++ b/tests/cff_1_0_3/d/test_zenodo_object.py
@@ -55,6 +55,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-07-25'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_0_3/e/.zenodo.json
+++ b/tests/cff_1_0_3/e/.zenodo.json
@@ -25,6 +25,11 @@
   "publication_date": "2018-05-09",
   "related_identifiers": [
     {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_0_3/e/.zenodo.json
+++ b/tests/cff_1_0_3/e/.zenodo.json
@@ -26,12 +26,12 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_0_3/e/.zenodo.json
+++ b/tests/cff_1_0_3/e/.zenodo.json
@@ -23,6 +23,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-05-09",
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "0.0.4"

--- a/tests/cff_1_0_3/e/test_zenodo_object.py
+++ b/tests/cff_1_0_3/e/test_zenodo_object.py
@@ -53,11 +53,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_0_3/e/test_zenodo_object.py
+++ b/tests/cff_1_0_3/e/test_zenodo_object.py
@@ -50,6 +50,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-05-09'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/a/.zenodo.json
+++ b/tests/cff_1_1_0/a/.zenodo.json
@@ -22,12 +22,12 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_1_0/a/.zenodo.json
+++ b/tests/cff_1_1_0/a/.zenodo.json
@@ -19,6 +19,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_1_0/a/.zenodo.json
+++ b/tests/cff_1_1_0/a/.zenodo.json
@@ -21,6 +21,11 @@
   "publication_date": "2018-01-16",
   "related_identifiers": [
     {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_1_0/a/test_zenodo_object.py
+++ b/tests/cff_1_1_0/a/test_zenodo_object.py
@@ -49,11 +49,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_1_0/a/test_zenodo_object.py
+++ b/tests/cff_1_1_0/a/test_zenodo_object.py
@@ -46,6 +46,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/b/.zenodo.json
+++ b/tests/cff_1_1_0/b/.zenodo.json
@@ -22,12 +22,12 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_1_0/b/.zenodo.json
+++ b/tests/cff_1_1_0/b/.zenodo.json
@@ -24,6 +24,11 @@
       "identifier": "10.5281/zenodo.1162057",
       "relation": "isSupplementTo",
       "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "cffconvert",

--- a/tests/cff_1_1_0/b/.zenodo.json
+++ b/tests/cff_1_1_0/b/.zenodo.json
@@ -19,6 +19,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_1_0/b/test_zenodo_object.py
+++ b/tests/cff_1_1_0/b/test_zenodo_object.py
@@ -49,11 +49,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_1_0/b/test_zenodo_object.py
+++ b/tests/cff_1_1_0/b/test_zenodo_object.py
@@ -46,6 +46,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/c/.zenodo.json
+++ b/tests/cff_1_1_0/c/.zenodo.json
@@ -19,6 +19,18 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.0000/FIXME",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_1_0/c/.zenodo.json
+++ b/tests/cff_1_1_0/c/.zenodo.json
@@ -22,17 +22,17 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "10.0000/FIXME",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_1_0/c/.zenodo.json
+++ b/tests/cff_1_1_0/c/.zenodo.json
@@ -29,6 +29,11 @@
       "identifier": "10.0000/FIXME",
       "relation": "isSupplementTo",
       "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "cffconvert",

--- a/tests/cff_1_1_0/c/test_zenodo_object.py
+++ b/tests/cff_1_1_0/c/test_zenodo_object.py
@@ -46,6 +46,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "10.0000/FIXME",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/c/test_zenodo_object.py
+++ b/tests/cff_1_1_0/c/test_zenodo_object.py
@@ -49,15 +49,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "10.0000/FIXME",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_1_0/d/.zenodo.json
+++ b/tests/cff_1_1_0/d/.zenodo.json
@@ -26,6 +26,11 @@
       "scheme": "doi"
     },
     {
+      "identifier": "10.0000/FIXME",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_1_0/d/.zenodo.json
+++ b/tests/cff_1_1_0/d/.zenodo.json
@@ -24,6 +24,11 @@
       "identifier": "10.5281/zenodo.1162057",
       "relation": "isSupplementTo",
       "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "cffconvert",

--- a/tests/cff_1_1_0/d/.zenodo.json
+++ b/tests/cff_1_1_0/d/.zenodo.json
@@ -22,17 +22,17 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "10.0000/FIXME",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_1_0/d/.zenodo.json
+++ b/tests/cff_1_1_0/d/.zenodo.json
@@ -19,6 +19,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_1_0/d/test_zenodo_object.py
+++ b/tests/cff_1_1_0/d/test_zenodo_object.py
@@ -46,6 +46,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "10.0000/FIXME",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/d/test_zenodo_object.py
+++ b/tests/cff_1_1_0/d/test_zenodo_object.py
@@ -49,15 +49,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "10.0000/FIXME",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_1_0/e/.zenodo.json
+++ b/tests/cff_1_1_0/e/.zenodo.json
@@ -22,6 +22,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_1_0/e/.zenodo.json
+++ b/tests/cff_1_1_0/e/.zenodo.json
@@ -25,17 +25,17 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "10.0000/FIXME",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_1_0/e/.zenodo.json
+++ b/tests/cff_1_1_0/e/.zenodo.json
@@ -27,6 +27,11 @@
       "identifier": "10.5281/zenodo.1162057",
       "relation": "isSupplementTo",
       "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "cffconvert",

--- a/tests/cff_1_1_0/e/.zenodo.json
+++ b/tests/cff_1_1_0/e/.zenodo.json
@@ -29,6 +29,11 @@
       "scheme": "doi"
     },
     {
+      "identifier": "10.0000/FIXME",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_1_0/e/test_zenodo_object.py
+++ b/tests/cff_1_1_0/e/test_zenodo_object.py
@@ -49,6 +49,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "10.0000/FIXME",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/e/test_zenodo_object.py
+++ b/tests/cff_1_1_0/e/test_zenodo_object.py
@@ -52,15 +52,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "10.0000/FIXME",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_1_0/f/.zenodo.json
+++ b/tests/cff_1_1_0/f/.zenodo.json
@@ -26,6 +26,11 @@
       "scheme": "doi"
     },
     {
+      "identifier": "10.0000/FIXME",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_1_0/f/.zenodo.json
+++ b/tests/cff_1_1_0/f/.zenodo.json
@@ -24,6 +24,11 @@
       "identifier": "10.5281/zenodo.1162057",
       "relation": "isSupplementTo",
       "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "cffconvert",

--- a/tests/cff_1_1_0/f/.zenodo.json
+++ b/tests/cff_1_1_0/f/.zenodo.json
@@ -22,17 +22,17 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "10.0000/FIXME",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_1_0/f/.zenodo.json
+++ b/tests/cff_1_1_0/f/.zenodo.json
@@ -19,6 +19,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_1_0/f/test_zenodo_object.py
+++ b/tests/cff_1_1_0/f/test_zenodo_object.py
@@ -46,6 +46,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "10.0000/FIXME",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/f/test_zenodo_object.py
+++ b/tests/cff_1_1_0/f/test_zenodo_object.py
@@ -49,15 +49,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "10.0000/FIXME",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_1_0/g/.zenodo.json
+++ b/tests/cff_1_1_0/g/.zenodo.json
@@ -30,6 +30,11 @@
       "scheme": "doi"
     },
     {
+      "identifier": "10.0000/FIXME",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementTo",
       "scheme": "url"

--- a/tests/cff_1_1_0/g/.zenodo.json
+++ b/tests/cff_1_1_0/g/.zenodo.json
@@ -28,6 +28,11 @@
       "identifier": "10.5281/zenodo.1162057",
       "relation": "isSupplementTo",
       "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "cffconvert",

--- a/tests/cff_1_1_0/g/.zenodo.json
+++ b/tests/cff_1_1_0/g/.zenodo.json
@@ -26,17 +26,17 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.1162057",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "10.0000/FIXME",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_1_0/g/.zenodo.json
+++ b/tests/cff_1_1_0/g/.zenodo.json
@@ -23,6 +23,13 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2018-01-16",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "cffconvert",
   "upload_type": "software",
   "version": "1.0.0"

--- a/tests/cff_1_1_0/g/test_zenodo_object.py
+++ b/tests/cff_1_1_0/g/test_zenodo_object.py
@@ -50,6 +50,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.5281/zenodo.1162057",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "10.0000/FIXME",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "https://github.com/citation-file-format/cffconvert",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_1_0/g/test_zenodo_object.py
+++ b/tests/cff_1_1_0/g/test_zenodo_object.py
@@ -53,15 +53,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "10.0000/FIXME",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_1_0/h/test_zenodo_object.py
+++ b/tests/cff_1_1_0/h/test_zenodo_object.py
@@ -46,6 +46,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date == '2018-01-16'
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'cffconvert'
 

--- a/tests/cff_1_2_0/authors/one/GFA_AOE/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/GFA_AOE/test_zenodo_object.py
@@ -43,6 +43,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/GFA_AO_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/GFA_AO_/test_zenodo_object.py
@@ -43,6 +43,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/GFA____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/GFA____/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/GF_____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/GF_____/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/G_A____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/G_A____/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/G______/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/G______/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/_FA____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/_FA____/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/_F_____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/_F_____/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/__AN___/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/__AN___/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/one/___N___/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/one/___N___/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/authors/two/GF_____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/authors/two/GF_____/test_zenodo_object.py
@@ -44,6 +44,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'the title'
 

--- a/tests/cff_1_2_0/identifiers/DI/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/DI/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "10.0000/from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     },
     {
       "identifier": "10.0000/from-doi",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/DI/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/DI/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "10.0000/from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/identifiers/DI/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/DI/.zenodo.json
@@ -9,6 +9,11 @@
       "identifier": "10.0000/from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "doi"
+    },
+    {
+      "identifier": "10.0000/from-doi",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/identifiers/DI/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/DI/test_zenodo_object.py
@@ -41,6 +41,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.0000/from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }, {
+            "identifier": "10.0000/from-doi",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/identifiers/DI/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/DI/test_zenodo_object.py
@@ -44,11 +44,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.0000/from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }, {
             "identifier": "10.0000/from-doi",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }]
 

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/.zenodo.json
@@ -1,0 +1,16 @@
+{
+  "creators": [
+    {
+      "name": "Test author"
+    }
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.0000/some-doi",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
+  "title": "Test title",
+  "upload_type": "software"
+}

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "10.0000/some-doi",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/CITATION.cff
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/CITATION.cff
@@ -1,0 +1,10 @@
+authors:
+  - name: "Test author"
+cff-version: "1.2.0"
+doi: "10.0000/some-doi"
+identifiers:
+  - description: "a doi"
+    value: 10.0000/some-doi
+    type: doi
+message: "test for constructing dois"
+title: Test title

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/apalike.txt
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/apalike.txt
@@ -1,0 +1,1 @@
+Test author Test title DOI: 10.0000/some-doi

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/bibtex.bib
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/bibtex.bib
@@ -1,0 +1,5 @@
+@misc{YourReferenceHere,
+author = {Test author},
+doi = {10.0000/some-doi},
+title = {Test title}
+}

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/codemeta.json
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/codemeta.json
@@ -1,0 +1,12 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "Test author"
+    }
+  ],
+  "identifier": "https://doi.org/10.0000/some-doi",
+  "name": "Test title"
+}

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/endnote.enw
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/endnote.enw
@@ -1,0 +1,4 @@
+%0 Generic
+%A Test author
+%R 10.0000/some-doi
+%T Test title

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/ris.txt
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/ris.txt
@@ -1,0 +1,5 @@
+TY  - GEN
+AU  - Test author
+DO  - 10.0000/some-doi
+TI  - Test title
+ER

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/schemaorg.json
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/schemaorg.json
@@ -1,0 +1,12 @@
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "Test author"
+    }
+  ],
+  "identifier": "https://doi.org/10.0000/some-doi",
+  "name": "Test title"
+}

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
@@ -1,0 +1,44 @@
+import os
+from tests.contracts.apalike_object import Contract
+from cffconvert import Citation
+from cffconvert.cff_1_2_x.apalike import ApalikeObject
+
+
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == 'Test author'
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi == 'DOI: 10.0000/some-doi'
+
+    def test_title(self):
+        assert apalike_object().add_title().title == 'Test title'
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_version(self):
+        assert apalike_object().add_version().version is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
@@ -1,0 +1,44 @@
+import os
+from tests.contracts.bibtex_object import Contract
+from cffconvert import Citation
+from cffconvert.cff_1_2_x.bibtex import BibtexObject
+
+
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class TestBibtexObject(Contract):
+
+    def test_as_string(self):
+        actual_bibtex = bibtex_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_author(self):
+        assert bibtex_object().add_author().author == 'author = {Test author}'
+
+    def test_check_cffobj(self):
+        bibtex_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert bibtex_object().add_doi().doi == 'doi = {10.0000/some-doi}'
+
+    def test_month(self):
+        assert bibtex_object().add_month().month is None
+
+    def test_title(self):
+        assert bibtex_object().add_title().title == 'title = {Test title}'
+
+    def test_url(self):
+        assert bibtex_object().add_url().url is None
+
+    def test_year(self):
+        assert bibtex_object().add_year().year is None

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_citation.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_citation.py
@@ -1,0 +1,17 @@
+import os
+from cffconvert.citation import Citation
+
+
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffversion():
+    assert citation().cffversion == "1.2.0"
+
+
+def test_validate():
+    citation().validate()

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_codemeta_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_codemeta_object.py
@@ -1,0 +1,62 @@
+import os
+from tests.contracts.codemeta_object import Contract
+from cffconvert import Citation
+from cffconvert.cff_1_2_x.codemeta import CodemetaObject
+
+
+def codemeta_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return CodemetaObject(citation.cffobj, initialize_empty=True)
+
+
+class TestCodemetaObject(Contract):
+
+    def test_as_string(self):
+        actual_codemeta = codemeta_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_codemeta = f.read()
+        assert actual_codemeta == expected_codemeta
+
+    def test_author(self):
+        assert codemeta_object().add_author().author == [{
+            "@type": "Organization",
+            "name": "Test author"
+        }]
+
+    def test_check_cffobj(self):
+        codemeta_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_code_repository(self):
+        assert codemeta_object().add_urls().code_repository is None
+
+    def test_date_published(self):
+        assert codemeta_object().add_date_published().date_published is None
+
+    def test_description(self):
+        assert codemeta_object().add_description().description is None
+
+    def test_identifier(self):
+        assert codemeta_object().add_identifier().identifier == 'https://doi.org/10.0000/some-doi'
+
+    def test_keywords(self):
+        assert codemeta_object().add_keywords().keywords is None
+
+    def test_license(self):
+        assert codemeta_object().add_license().license is None
+
+    def test_name(self):
+        assert codemeta_object().add_name().name == 'Test title'
+
+    def test_upload_type(self):
+        assert codemeta_object().add_type().type == "SoftwareSourceCode"
+
+    def test_url(self):
+        assert codemeta_object().add_urls().url is None
+
+    def test_version(self):
+        assert codemeta_object().add_version().version is None

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_endnote_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_endnote_object.py
@@ -1,0 +1,44 @@
+import os
+from tests.contracts.endnote_object import Contract
+from cffconvert import Citation
+from cffconvert.cff_1_2_x.endnote import EndnoteObject
+
+
+def endnote_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return EndnoteObject(citation.cffobj, initialize_empty=True)
+
+
+class TestEndnoteObject(Contract):
+
+    def test_as_string(self):
+        actual_endnote = endnote_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_endnote = f.read()
+        assert actual_endnote == expected_endnote
+
+    def test_author(self):
+        assert endnote_object().add_author().author == '%A Test author\n'
+
+    def test_check_cffobj(self):
+        endnote_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert endnote_object().add_doi().doi == '%R 10.0000/some-doi\n'
+
+    def test_keyword(self):
+        assert endnote_object().add_keyword().keyword is None
+
+    def test_name(self):
+        assert endnote_object().add_name().name == '%T Test title\n'
+
+    def test_url(self):
+        assert endnote_object().add_url().url is None
+
+    def test_year(self):
+        assert endnote_object().add_year().year is None

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_ris_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_ris_object.py
@@ -1,0 +1,50 @@
+import os
+from tests.contracts.ris_object import Contract
+from cffconvert import Citation
+from cffconvert.cff_1_2_x.ris import RisObject
+
+
+def ris_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return RisObject(citation.cffobj, initialize_empty=True)
+
+
+class TestRisObject(Contract):
+
+    def test_abstract(self):
+        assert ris_object().add_abstract().abstract is None
+
+    def test_as_string(self):
+        actual_ris = ris_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "ris.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_ris = f.read()
+        assert actual_ris == expected_ris
+
+    def test_author(self):
+        assert ris_object().add_author().author == 'AU  - Test author\n'
+
+    def test_check_cffobj(self):
+        ris_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_date(self):
+        assert ris_object().add_date().date is None
+
+    def test_doi(self):
+        assert ris_object().add_doi().doi == 'DO  - 10.0000/some-doi\n'
+
+    def test_keywords(self):
+        assert ris_object().add_keywords().keywords is None
+
+    def test_title(self):
+        assert ris_object().add_title().title == 'TI  - Test title\n'
+
+    def test_url(self):
+        assert ris_object().add_url().url is None
+
+    def test_year(self):
+        assert ris_object().add_year().year is None

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_schemaorg_object.py
@@ -1,0 +1,62 @@
+import os
+from tests.contracts.schemaorg_object import Contract
+from cffconvert import Citation
+from cffconvert.cff_1_2_x.schemaorg import SchemaorgObject
+
+
+def schemaorg_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return SchemaorgObject(citation.cffobj, initialize_empty=True)
+
+
+class TestSchemaorgObject(Contract):
+
+    def test_as_string(self):
+        actual_schemaorg = schemaorg_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_schemaorg = f.read()
+        assert actual_schemaorg == expected_schemaorg
+
+    def test_author(self):
+        assert schemaorg_object().add_author().author == [{
+            "@type": "Organization",
+            "name": "Test author"
+        }]
+
+    def test_check_cffobj(self):
+        schemaorg_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_code_repository(self):
+        assert schemaorg_object().add_urls().code_repository is None
+
+    def test_date_published(self):
+        assert schemaorg_object().add_date_published().date_published is None
+
+    def test_description(self):
+        assert schemaorg_object().add_description().description is None
+
+    def test_identifier(self):
+        assert schemaorg_object().add_identifier().identifier == 'https://doi.org/10.0000/some-doi'
+
+    def test_keywords(self):
+        assert schemaorg_object().add_keywords().keywords is None
+
+    def test_license(self):
+        assert schemaorg_object().add_license().license is None
+
+    def test_name(self):
+        assert schemaorg_object().add_name().name == 'Test title'
+
+    def test_upload_type(self):
+        assert schemaorg_object().add_type().type == "SoftwareSourceCode"
+
+    def test_url(self):
+        assert schemaorg_object().add_urls().url is None
+
+    def test_version(self):
+        assert schemaorg_object().add_version().version is None

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
@@ -44,7 +44,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.0000/some-doi",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }]
 

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
@@ -41,6 +41,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.0000/some-doi",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
@@ -1,0 +1,51 @@
+import os
+from tests.contracts.zenodo_object import Contract
+from cffconvert import Citation
+from cffconvert.cff_1_2_x.zenodo import ZenodoObject
+
+
+def zenodo_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ZenodoObject(citation.cffobj, initialize_empty=True)
+
+
+class TestZenodoObject(Contract):
+
+    def test_as_string(self):
+        actual_zenodo = zenodo_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_zenodo = f.read()
+        assert actual_zenodo == expected_zenodo
+
+    def test_check_cffobj(self):
+        zenodo_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_creators(self):
+        assert zenodo_object().add_creators().creators == [
+            {
+                "name": "Test author"
+            }
+        ]
+
+    def test_keywords(self):
+        assert zenodo_object().add_keywords().keywords is None
+
+    def test_license(self):
+        assert zenodo_object().add_license().license is None
+
+    def test_publication_date(self):
+        assert zenodo_object().add_publication_date().publication_date is None
+
+    def test_title(self):
+        assert zenodo_object().add_title().title == 'Test title'
+
+    def test_upload_type(self):
+        assert zenodo_object().add_upload_type().upload_type == 'software'
+
+    def test_version(self):
+        assert zenodo_object().add_version().version is None

--- a/tests/cff_1_2_0/identifiers/D_/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/D_/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "10.0000/from-doi",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/identifiers/D_/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/D_/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "10.0000/from-doi",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/D_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/D_/test_zenodo_object.py
@@ -44,7 +44,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.0000/from-doi",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }]
 

--- a/tests/cff_1_2_0/identifiers/D_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/D_/test_zenodo_object.py
@@ -41,6 +41,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.0000/from-doi",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/identifiers/_I/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/_I/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "10.0000/from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "doi"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/_I/.zenodo.json
+++ b/tests/cff_1_2_0/identifiers/_I/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "10.0000/from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/identifiers/_I/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/_I/test_zenodo_object.py
@@ -44,7 +44,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "10.0000/from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "doi"
         }]
 

--- a/tests/cff_1_2_0/identifiers/_I/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/_I/test_zenodo_object.py
@@ -41,6 +41,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "10.0000/from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "doi"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/identifiers/__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/identifiers/__/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/types/dataset/test_zenodo_object.py
+++ b/tests/cff_1_2_0/types/dataset/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == "The title"
 

--- a/tests/cff_1_2_0/types/none/test_zenodo_object.py
+++ b/tests/cff_1_2_0/types/none/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == "The title"
 

--- a/tests/cff_1_2_0/types/software/test_zenodo_object.py
+++ b/tests/cff_1_2_0/types/software/test_zenodo_object.py
@@ -41,6 +41,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == "The title"
 

--- a/tests/cff_1_2_0/urls/IRACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRACU/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IRACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRACU/.zenodo.json
@@ -9,6 +9,26 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IRACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRACU/.zenodo.json
@@ -7,27 +7,27 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRACU/test_zenodo_object.py
@@ -42,23 +42,23 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/IRACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRACU/test_zenodo_object.py
@@ -39,6 +39,29 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IRAC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRAC_/.zenodo.json
@@ -9,6 +9,21 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IRAC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRAC_/.zenodo.json
@@ -7,22 +7,22 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRAC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRAC_/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
@@ -42,19 +42,19 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
@@ -39,6 +39,25 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IRA_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRA_U/.zenodo.json
@@ -9,6 +9,21 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IRA_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRA_U/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IRA_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRA_U/.zenodo.json
@@ -7,22 +7,22 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
@@ -39,6 +39,25 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
@@ -42,19 +42,19 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/IRA__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRA__/.zenodo.json
@@ -9,6 +9,16 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IRA__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRA__/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IRA__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IRA__/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRA__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRA__/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/IRA__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IRA__/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IR_CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR_CU/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IR_CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR_CU/.zenodo.json
@@ -7,22 +7,22 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR_CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR_CU/.zenodo.json
@@ -9,6 +9,21 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
@@ -39,6 +39,25 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
@@ -42,19 +42,19 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/IR_C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR_C_/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR_C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR_C_/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IR_C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR_C_/.zenodo.json
@@ -9,6 +9,16 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/IR__U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR__U/.zenodo.json
@@ -9,6 +9,16 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IR__U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR__U/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IR__U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR__U/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR__U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR__U/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/IR__U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR__U/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IR___/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR___/.zenodo.json
@@ -9,6 +9,11 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/IR___/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR___/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/IR___/.zenodo.json
+++ b/tests/cff_1_2_0/urls/IR___/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR___/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR___/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/IR___/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/IR___/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I_ACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_ACU/.zenodo.json
@@ -7,22 +7,22 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_ACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_ACU/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I_ACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_ACU/.zenodo.json
@@ -9,6 +9,21 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
@@ -42,19 +42,19 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
@@ -39,6 +39,25 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/I_AC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_AC_/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I_AC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_AC_/.zenodo.json
@@ -9,6 +9,16 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/I_AC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_AC_/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I_A_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_A_U/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I_A_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_A_U/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_A_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_A_U/.zenodo.json
@@ -9,6 +9,16 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I_A__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_A__/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_A__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_A__/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I_A__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I_A__/.zenodo.json
@@ -9,6 +9,11 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/I_A__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_A__/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I_A__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I_A__/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/I__CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I__CU/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I__CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I__CU/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I__CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I__CU/.zenodo.json
@@ -9,6 +9,16 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/I__CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I__CU/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/I__CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I__CU/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I__C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I__C_/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I__C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I__C_/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I__C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I__C_/.zenodo.json
@@ -9,6 +9,11 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/I__C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I__C_/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/I__C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I__C_/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I___U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I___U/.zenodo.json
@@ -9,6 +9,11 @@
       "identifier": "https://github.com/the-url-from-identifiers",
       "relation": "isSupplementTo",
       "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
     }
   ],
   "title": "Test title",

--- a/tests/cff_1_2_0/urls/I___U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I___U/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I___U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I___U/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I___U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I___U/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I___U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I___U/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/I____/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I____/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-identifiers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/I____/.zenodo.json
+++ b/tests/cff_1_2_0/urls/I____/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-identifiers",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/I____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I____/test_zenodo_object.py
@@ -42,7 +42,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/I____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/I____/test_zenodo_object.py
@@ -39,6 +39,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-identifiers",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_RACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RACU/.zenodo.json
@@ -4,6 +4,28 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_RACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RACU/.zenodo.json
@@ -7,22 +7,22 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RACU/test_zenodo_object.py
@@ -39,6 +39,25 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_RACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RACU/test_zenodo_object.py
@@ -42,19 +42,19 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_RAC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RAC_/.zenodo.json
@@ -4,6 +4,23 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_RAC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RAC_/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_RA_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RA_U/.zenodo.json
@@ -4,6 +4,23 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_RA_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RA_U/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_RA__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RA__/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RA__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_RA__/.zenodo.json
@@ -4,6 +4,18 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_RA__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RA__/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_RA__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_RA__/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_R_CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R_CU/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R_CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R_CU/.zenodo.json
@@ -4,6 +4,23 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_R_C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R_C_/.zenodo.json
@@ -4,6 +4,18 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_R_C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R_C_/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_R__U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R__U/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R__U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R__U/.zenodo.json
@@ -4,6 +4,18 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_R__U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R__U/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/_R__U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R__U/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_R___/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R___/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/_R___/.zenodo.json
+++ b/tests/cff_1_2_0/urls/_R___/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R___/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R___/test_zenodo_object.py
@@ -42,7 +42,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_R___/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_R___/test_zenodo_object.py
@@ -39,6 +39,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/__ACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__ACU/.zenodo.json
@@ -7,17 +7,17 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/__ACU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__ACU/.zenodo.json
@@ -4,6 +4,23 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/__ACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__ACU/test_zenodo_object.py
@@ -42,15 +42,15 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/__ACU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__ACU/test_zenodo_object.py
@@ -39,6 +39,21 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/__AC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__AC_/.zenodo.json
@@ -4,6 +4,18 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/__AC_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__AC_/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/__AC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__AC_/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/__AC_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__AC_/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/__A_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__A_U/.zenodo.json
@@ -4,6 +4,18 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/__A_U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__A_U/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/__A_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__A_U/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/__A_U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__A_U/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/__A__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__A__/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/__A__/.zenodo.json
+++ b/tests/cff_1_2_0/urls/__A__/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository-artifact",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/__A__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__A__/test_zenodo_object.py
@@ -42,7 +42,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/__A__/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/__A__/test_zenodo_object.py
@@ -39,6 +39,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository-artifact",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/___CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/___CU/.zenodo.json
@@ -7,12 +7,12 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/___CU/.zenodo.json
+++ b/tests/cff_1_2_0/urls/___CU/.zenodo.json
@@ -4,6 +4,18 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/___CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/___CU/test_zenodo_object.py
@@ -42,11 +42,11 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/___CU/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/___CU/test_zenodo_object.py
@@ -39,6 +39,17 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }, {
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/___C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/___C_/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-repository-code",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/___C_/.zenodo.json
+++ b/tests/cff_1_2_0/urls/___C_/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-repository-code",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/___C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/___C_/test_zenodo_object.py
@@ -42,7 +42,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/___C_/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/___C_/test_zenodo_object.py
@@ -39,6 +39,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-repository-code",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/____U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/____U/.zenodo.json
@@ -4,6 +4,13 @@
       "name": "Test author"
     }
   ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/the-url-from-url",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ],
   "title": "Test title",
   "upload_type": "software"
 }

--- a/tests/cff_1_2_0/urls/____U/.zenodo.json
+++ b/tests/cff_1_2_0/urls/____U/.zenodo.json
@@ -7,7 +7,7 @@
   "related_identifiers": [
     {
       "identifier": "https://github.com/the-url-from-url",
-      "relation": "isSupplementTo",
+      "relation": "isSupplementedBy",
       "scheme": "url"
     }
   ],

--- a/tests/cff_1_2_0/urls/____U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/____U/test_zenodo_object.py
@@ -39,6 +39,13 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers == [{
+            "identifier": "https://github.com/the-url-from-url",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        }]
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/cff_1_2_0/urls/____U/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/____U/test_zenodo_object.py
@@ -42,7 +42,7 @@ class TestZenodoObject(Contract):
     def test_related_identifiers(self):
         assert zenodo_object().add_related_identifiers().related_identifiers == [{
             "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementTo",
+            "relation": "isSupplementedBy",
             "scheme": "url"
         }]
 

--- a/tests/cff_1_2_0/urls/_____/test_zenodo_object.py
+++ b/tests/cff_1_2_0/urls/_____/test_zenodo_object.py
@@ -39,6 +39,9 @@ class TestZenodoObject(Contract):
     def test_publication_date(self):
         assert zenodo_object().add_publication_date().publication_date is None
 
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
     def test_title(self):
         assert zenodo_object().add_title().title == 'Test title'
 

--- a/tests/contracts/zenodo_object.py
+++ b/tests/contracts/zenodo_object.py
@@ -33,6 +33,10 @@ class Contract(ABC):
         pass
 
     @abstractmethod
+    def test_related_identifiers(self):
+        pass
+
+    @abstractmethod
     def test_upload_type(self):
         pass
 


### PR DESCRIPTION
Refs:

- #235

In this PR:

- added method for generating Zenodo's `related_identifiers` in `.zenodo.json` files based on:
    - `identifiers` (url, doi, swh)
    - `doi`
    - `repository`
    - `repository-artifact`
    - `repository-code`
    - `url`
- updated `.zenodo.json` files from `tests/` accordingly
- updated testing contract for `ZenodoObject` with new method `test_related_identifiers`
- updated `test_zenodo_object.py` files from `tests/` with the newly added `test_related_identifiers` method


Tested by uploading metadata to Zenodo Sandbox.

