### PR TITLE
updated previously invalid cff file used in testing

### DIFF
--- a/tests/cff_1_0_3/c/.zenodo.json
+++ b/tests/cff_1_0_3/c/.zenodo.json
@@ -2,12 +2,12 @@
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",
-      "name": "Attema, Jisk"
+      "name": "Attema, Jisk",
+      "orcid": "0000-0002-0948-1176"
     },
     {
       "affiliation": "Netherlands eScience Center",
-      "name": "Diblen, Faruk",
-      "orcid": "0000-0002-0989-929X"
+      "name": "Diblen, Faruk"
     }
   ],
   "keywords": [

--- a/tests/cff_1_0_3/c/CITATION.cff
+++ b/tests/cff_1_0_3/c/CITATION.cff
@@ -5,11 +5,11 @@ authors:
     affiliation: "Netherlands eScience Center"
     family-names: Attema
     given-names: Jisk
+    orcid: "https://orcid.org/0000-0002-0948-1176"
   - 
     affiliation: "Netherlands eScience Center"
     family-names: Diblen
     given-names: Faruk
-    orcid: "https://orcid.org/0000-0002-0989-929X"
 cff-version: "1.0.3"
 commit: aa98969b99151c507d9502a1bf9bd1071e31af8a
 date-released: 2017-10-07

--- a/tests/cff_1_0_3/c/codemeta.json
+++ b/tests/cff_1_0_3/c/codemeta.json
@@ -3,6 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
+      "@id": "https://orcid.org/0000-0002-0948-1176",
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
@@ -12,7 +13,6 @@
       "givenName": "Jisk"
     },
     {
-      "@id": "https://orcid.org/0000-0002-0989-929X",
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",

--- a/tests/cff_1_0_3/c/schemaorg.json
+++ b/tests/cff_1_0_3/c/schemaorg.json
@@ -3,6 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
+      "@id": "https://orcid.org/0000-0002-0948-1176",
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
@@ -12,7 +13,6 @@
       "givenName": "Jisk"
     },
     {
-      "@id": "https://orcid.org/0000-0002-0989-929X",
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",

--- a/tests/cff_1_0_3/c/test_citation.py
+++ b/tests/cff_1_0_3/c/test_citation.py
@@ -1,7 +1,5 @@
 import datetime
 import os
-import pykwalify
-import pytest
 from cffconvert.citation import Citation
 
 
@@ -22,8 +20,4 @@ def test_cffversion():
 
 
 def test_validate():
-    with pytest.raises(pykwalify.errors.SchemaError) as e:
-        citation().validate()
-    msg = str(e.value)
-    # ORCIDs ending in X were not supported in 1.0.3
-    assert "Value 'https://orcid.org/0000-0002-0989-929X' does not match pattern" in msg
+    citation().validate()

--- a/tests/cff_1_0_3/c/test_codemeta_object.py
+++ b/tests/cff_1_0_3/c/test_codemeta_object.py
@@ -23,6 +23,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
+            "@id": "https://orcid.org/0000-0002-0948-1176",
             "@type": "Person",
             "givenName": "Jisk",
             "familyName": "Attema",
@@ -31,7 +32,6 @@ class TestCodemetaObject(Contract):
                 "legalName": "Netherlands eScience Center"
             }
         }, {
-            "@id": "https://orcid.org/0000-0002-0989-929X",
             "@type": "Person",
             "givenName": "Faruk",
             "familyName": "Diblen",

--- a/tests/cff_1_0_3/c/test_schemaorg_object.py
+++ b/tests/cff_1_0_3/c/test_schemaorg_object.py
@@ -23,6 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
+            "@id": "https://orcid.org/0000-0002-0948-1176",
             "@type": "Person",
             "givenName": "Jisk",
             "familyName": "Attema",
@@ -31,7 +32,6 @@ class TestSchemaorgObject(Contract):
                 "legalName": "Netherlands eScience Center"
             }
         }, {
-            "@id": "https://orcid.org/0000-0002-0989-929X",
             "@type": "Person",
             "givenName": "Faruk",
             "familyName": "Diblen",

--- a/tests/cff_1_0_3/c/test_zenodo_object.py
+++ b/tests/cff_1_0_3/c/test_zenodo_object.py
@@ -29,12 +29,12 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_creators().creators == [
             {
                 "affiliation": "Netherlands eScience Center",
-                "name": "Attema, Jisk"
+                "name": "Attema, Jisk",
+                "orcid": "0000-0002-0948-1176"
             },
             {
                 "affiliation": "Netherlands eScience Center",
-                "name": "Diblen, Faruk",
-                "orcid": "0000-0002-0989-929X"
+                "name": "Diblen, Faruk"
             }
         ]
 


### PR DESCRIPTION
Refs:

- #297

This PR updates a CITATION.cff file that was used in testing but didnt pass validation because of an issue with one of the authors' orcid ending in `X` (which is legal but the 1.0.3 schema didnt recognize that). Fixed by removing the orcid key altogether and using the other author's orcid instead.


```shell
find ./tests -type f -name CITATION.cff -exec cffconvert -i {} --validate \; 
```

show all passing now whereas `main` had an error for `tests/cff_1_0_3/c/CITATION.cff`