### PR TITLE
Legalname revisited

### DIFF
--- a/src/cffconvert/cff_1_x_x/authors/schemaorg.py
+++ b/src/cffconvert/cff_1_x_x/authors/schemaorg.py
@@ -142,7 +142,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'email': self._author.get('email')
         }
@@ -153,7 +153,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'email': self._author.get('email')
         }
@@ -170,7 +170,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'email': self._author.get('email')
@@ -182,7 +182,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'email': self._author.get('email')
@@ -231,7 +231,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'givenName': self._author.get('given-names'),
             'email': self._author.get('email')
@@ -243,7 +243,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'givenName': self._author.get('given-names'),
             'email': self._author.get('email')
@@ -262,7 +262,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'givenName': self._author.get('given-names'),
@@ -275,7 +275,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'givenName': self._author.get('given-names'),
@@ -304,7 +304,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name(),
             'givenName': self._author.get('given-names'),
@@ -317,7 +317,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name(),
             'givenName': self._author.get('given-names'),
@@ -338,7 +338,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name(),
@@ -352,7 +352,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name(),
@@ -399,7 +399,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name(),
             'email': self._author.get('email')
@@ -411,7 +411,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name(),
             'email': self._author.get('email')
@@ -430,7 +430,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name(),
@@ -443,7 +443,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name(),
@@ -494,7 +494,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             }
         }
 
@@ -504,7 +504,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             }
         }
 
@@ -519,7 +519,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
         }
@@ -530,7 +530,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
         }
@@ -568,7 +568,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'givenName': self._author.get('given-names')
         }
@@ -579,7 +579,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'givenName': self._author.get('given-names')
         }
@@ -596,7 +596,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'givenName': self._author.get('given-names')
@@ -608,7 +608,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'givenName': self._author.get('given-names')
@@ -634,7 +634,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name(),
             'givenName': self._author.get('given-names')
@@ -646,7 +646,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name(),
             'givenName': self._author.get('given-names')
@@ -665,7 +665,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name(),
@@ -678,7 +678,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name(),
@@ -720,7 +720,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name()
         }
@@ -731,7 +731,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'familyName': self._get_full_last_name()
         }
@@ -748,7 +748,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name()
@@ -760,7 +760,7 @@ class SchemaorgAuthor(BaseAuthor):
             '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
+                'name': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
             'familyName': self._get_full_last_name()

--- a/tests/cff_1_0_3/a/codemeta.json
+++ b/tests/cff_1_0_3/a/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "email": "my@email.notexist",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_0_3/a/schemaorg.json
+++ b/tests/cff_1_0_3/a/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "email": "my@email.notexist",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_0_3/a/test_codemeta_object.py
+++ b/tests/cff_1_0_3/a/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H.",
@@ -37,7 +37,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_0_3/a/test_schemaorg_object.py
+++ b/tests/cff_1_0_3/a/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H.",
@@ -37,7 +37,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_0_3/c/codemeta.json
+++ b/tests/cff_1_0_3/c/codemeta.json
@@ -7,7 +7,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Attema",
       "givenName": "Jisk"
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Diblen",
       "givenName": "Faruk"

--- a/tests/cff_1_0_3/c/schemaorg.json
+++ b/tests/cff_1_0_3/c/schemaorg.json
@@ -7,7 +7,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Attema",
       "givenName": "Jisk"
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Diblen",
       "givenName": "Faruk"

--- a/tests/cff_1_0_3/c/test_codemeta_object.py
+++ b/tests/cff_1_0_3/c/test_codemeta_object.py
@@ -31,7 +31,7 @@ class TestCodemetaObject(Contract):
             "familyName": "Attema",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             }
         }, {
             "@type": "Person",
@@ -39,7 +39,7 @@ class TestCodemetaObject(Contract):
             "familyName": "Diblen",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             }
         }]
 

--- a/tests/cff_1_0_3/c/test_schemaorg_object.py
+++ b/tests/cff_1_0_3/c/test_schemaorg_object.py
@@ -31,7 +31,7 @@ class TestSchemaorgObject(Contract):
             "familyName": "Attema",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             }
         }, {
             "@type": "Person",
@@ -39,7 +39,7 @@ class TestSchemaorgObject(Contract):
             "familyName": "Diblen",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             }
         }]
 

--- a/tests/cff_1_0_3/d/codemeta.json
+++ b/tests/cff_1_0_3/d/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"
@@ -24,7 +24,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Verhoeven",
       "givenName": "Stefan"
@@ -34,7 +34,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Humboldt-Universität zu Berlin"
+        "name": "Humboldt-Universität zu Berlin"
       },
       "familyName": "Druskat",
       "givenName": "Stephan"

--- a/tests/cff_1_0_3/d/schemaorg.json
+++ b/tests/cff_1_0_3/d/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"
@@ -24,7 +24,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Verhoeven",
       "givenName": "Stefan"
@@ -34,7 +34,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Humboldt-Universität zu Berlin"
+        "name": "Humboldt-Universität zu Berlin"
       },
       "familyName": "Druskat",
       "givenName": "Stephan"

--- a/tests/cff_1_0_3/d/test_codemeta_object.py
+++ b/tests/cff_1_0_3/d/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"
@@ -44,7 +44,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Verhoeven",
             "givenName": "Stefan"
@@ -53,7 +53,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Humboldt-Universität zu Berlin"
+                "name": "Humboldt-Universität zu Berlin"
             },
             "familyName": "Druskat",
             "givenName": "Stephan"

--- a/tests/cff_1_0_3/d/test_schemaorg_object.py
+++ b/tests/cff_1_0_3/d/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"
@@ -44,7 +44,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Verhoeven",
             "givenName": "Stefan"
@@ -53,7 +53,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Humboldt-Universität zu Berlin"
+                "name": "Humboldt-Universität zu Berlin"
             },
             "familyName": "Druskat",
             "givenName": "Stephan"

--- a/tests/cff_1_0_3/e/codemeta.json
+++ b/tests/cff_1_0_3/e/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"
@@ -24,7 +24,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Verhoeven",
       "givenName": "Stefan"

--- a/tests/cff_1_0_3/e/schemaorg.json
+++ b/tests/cff_1_0_3/e/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"
@@ -24,7 +24,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Verhoeven",
       "givenName": "Stefan"

--- a/tests/cff_1_0_3/e/test_codemeta_object.py
+++ b/tests/cff_1_0_3/e/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"
@@ -44,7 +44,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Verhoeven",
             "givenName": "Stefan"

--- a/tests/cff_1_0_3/e/test_schemaorg_object.py
+++ b/tests/cff_1_0_3/e/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"
@@ -44,7 +44,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Verhoeven",
             "givenName": "Stefan"

--- a/tests/cff_1_1_0/a/codemeta.json
+++ b/tests/cff_1_1_0/a/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "email": "my@email.notexist",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/a/schemaorg.json
+++ b/tests/cff_1_1_0/a/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "email": "my@email.notexist",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/a/test_codemeta_object.py
+++ b/tests/cff_1_1_0/a/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "email": "my@email.notexist",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/a/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/a/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "email": "my@email.notexist",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/b/codemeta.json
+++ b/tests/cff_1_1_0/b/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/b/schemaorg.json
+++ b/tests/cff_1_1_0/b/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/b/test_codemeta_object.py
+++ b/tests/cff_1_1_0/b/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/b/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/b/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/c/codemeta.json
+++ b/tests/cff_1_1_0/c/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/c/schemaorg.json
+++ b/tests/cff_1_1_0/c/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/c/test_codemeta_object.py
+++ b/tests/cff_1_1_0/c/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/c/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/c/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/d/codemeta.json
+++ b/tests/cff_1_1_0/d/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/d/schemaorg.json
+++ b/tests/cff_1_1_0/d/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/d/test_codemeta_object.py
+++ b/tests/cff_1_1_0/d/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/d/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/d/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
@@ -36,7 +36,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/e/codemeta.json
+++ b/tests/cff_1_1_0/e/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/e/schemaorg.json
+++ b/tests/cff_1_1_0/e/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/e/test_codemeta_object.py
+++ b/tests/cff_1_1_0/e/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/e/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/e/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/f/codemeta.json
+++ b/tests/cff_1_1_0/f/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/f/schemaorg.json
+++ b/tests/cff_1_1_0/f/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"

--- a/tests/cff_1_1_0/f/test_codemeta_object.py
+++ b/tests/cff_1_1_0/f/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/f/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/f/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"

--- a/tests/cff_1_1_0/g/codemeta.json
+++ b/tests/cff_1_1_0/g/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"
@@ -25,7 +25,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "MyAffiliation"
+        "name": "MyAffiliation"
       },
       "alternateName": "mysteryauthor"
     }

--- a/tests/cff_1_1_0/g/schemaorg.json
+++ b/tests/cff_1_1_0/g/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "Spaaks",
@@ -16,7 +16,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "familyName": "Klaver",
       "givenName": "Tom"
@@ -25,7 +25,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "MyAffiliation"
+        "name": "MyAffiliation"
       },
       "alternateName": "mysteryauthor"
     }

--- a/tests/cff_1_1_0/g/test_codemeta_object.py
+++ b/tests/cff_1_1_0/g/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"
@@ -45,7 +45,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "MyAffiliation"
+                "name": "MyAffiliation"
             },
             "alternateName": "mysteryauthor"
         }]

--- a/tests/cff_1_1_0/g/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/g/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "Spaaks",
@@ -37,7 +37,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "familyName": "Klaver",
             "givenName": "Tom"
@@ -45,7 +45,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "MyAffiliation"
+                "name": "MyAffiliation"
             },
             "alternateName": "mysteryauthor"
         }]

--- a/tests/cff_1_1_0/h/codemeta.json
+++ b/tests/cff_1_1_0/h/codemeta.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Springsteen"
+        "name": "Springsteen"
       },
       "familyName": "Van Zandt",
       "givenName": "Steven"
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "coverband"
+        "name": "coverband"
       },
       "familyName": "van Zandt",
       "givenName": "Steven"

--- a/tests/cff_1_1_0/h/schemaorg.json
+++ b/tests/cff_1_1_0/h/schemaorg.json
@@ -6,7 +6,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Springsteen"
+        "name": "Springsteen"
       },
       "familyName": "Van Zandt",
       "givenName": "Steven"
@@ -15,7 +15,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "coverband"
+        "name": "coverband"
       },
       "familyName": "van Zandt",
       "givenName": "Steven"

--- a/tests/cff_1_1_0/h/test_codemeta_object.py
+++ b/tests/cff_1_1_0/h/test_codemeta_object.py
@@ -28,7 +28,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Springsteen"
+                "name": "Springsteen"
             },
             "familyName": "Van Zandt",
             "givenName": "Steven"
@@ -36,7 +36,7 @@ class TestCodemetaObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "coverband"
+                "name": "coverband"
             },
             "familyName": "van Zandt",
             "givenName": "Steven"

--- a/tests/cff_1_1_0/h/test_schemaorg_object.py
+++ b/tests/cff_1_1_0/h/test_schemaorg_object.py
@@ -28,7 +28,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Springsteen"
+                "name": "Springsteen"
             },
             "familyName": "Van Zandt",
             "givenName": "Steven"
@@ -36,7 +36,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "coverband"
+                "name": "coverband"
             },
             "familyName": "van Zandt",
             "givenName": "Steven"

--- a/tests/cff_1_2_0/authors/one/GFA_AOE/schemaorg.json
+++ b/tests/cff_1_2_0/authors/one/GFA_AOE/schemaorg.json
@@ -7,7 +7,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "email": "my@email.notexist",

--- a/tests/cff_1_2_0/authors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/authors/one/GFA_AOE/test_schemaorg_object.py
@@ -26,7 +26,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "email": "my@email.notexist",

--- a/tests/cff_1_2_0/authors/one/GFA_AO_/schemaorg.json
+++ b/tests/cff_1_2_0/authors/one/GFA_AO_/schemaorg.json
@@ -7,7 +7,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "von der Spaaks Jr.",

--- a/tests/cff_1_2_0/authors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/authors/one/GFA_AO_/test_schemaorg_object.py
@@ -26,7 +26,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "von der Spaaks Jr.",

--- a/tests/cff_1_3_0/authors/one/GFA_AOE/schemaorg.json
+++ b/tests/cff_1_3_0/authors/one/GFA_AOE/schemaorg.json
@@ -7,7 +7,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "email": "my@email.notexist",

--- a/tests/cff_1_3_0/authors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/cff_1_3_0/authors/one/GFA_AOE/test_schemaorg_object.py
@@ -26,7 +26,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "email": "my@email.notexist",

--- a/tests/cff_1_3_0/authors/one/GFA_AO_/schemaorg.json
+++ b/tests/cff_1_3_0/authors/one/GFA_AO_/schemaorg.json
@@ -7,7 +7,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "von der Spaaks Jr.",

--- a/tests/cff_1_3_0/authors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/cff_1_3_0/authors/one/GFA_AO_/test_schemaorg_object.py
@@ -26,7 +26,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "von der Spaaks Jr.",

--- a/tests/cff_1_3_0/contributors/one/GFA_AOE/schemaorg.json
+++ b/tests/cff_1_3_0/contributors/one/GFA_AOE/schemaorg.json
@@ -13,7 +13,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "email": "my@email.notexist",

--- a/tests/cff_1_3_0/contributors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/cff_1_3_0/contributors/one/GFA_AOE/test_schemaorg_object.py
@@ -42,7 +42,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "email": "my@email.notexist",

--- a/tests/cff_1_3_0/contributors/one/GFA_AO_/schemaorg.json
+++ b/tests/cff_1_3_0/contributors/one/GFA_AO_/schemaorg.json
@@ -13,7 +13,7 @@
       "@type": "Person",
       "affiliation": {
         "@type": "Organization",
-        "legalName": "Netherlands eScience Center"
+        "name": "Netherlands eScience Center"
       },
       "alternateName": "jspaaks",
       "familyName": "von der Spaaks Jr.",

--- a/tests/cff_1_3_0/contributors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/cff_1_3_0/contributors/one/GFA_AO_/test_schemaorg_object.py
@@ -42,7 +42,7 @@ class TestSchemaorgObject(Contract):
             "@type": "Person",
             "affiliation": {
                 "@type": "Organization",
-                "legalName": "Netherlands eScience Center"
+                "name": "Netherlands eScience Center"
             },
             "alternateName": "jspaaks",
             "familyName": "von der Spaaks Jr.",


### PR DESCRIPTION
This PR changes an `affiliation`'s `legalName` to `name` in schema.org and codemeta exports.

Refs: 

- #272 
