### PR TITLE
bumped cffconvert version to 3.0.0a0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,27 +1,58 @@
 {
+  "contributors": [
+    {
+      "affiliation": "University of Oslo",
+      "name": "Leoncio Netto, Waldir",
+      "type": "Other"
+    },
+    {
+      "affiliation": "Humboldt-Universität zu Berlin",
+      "name": "Druskat, Stephan",
+      "orcid": "0000-0003-4925-7248",
+      "type": "Other"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Klaver, Tom",
+      "type": "Other"
+    },
+    {
+      "name": "Moon, Zachary",
+      "type": "Other"
+    },
+    {
+      "name": "Ovaskainen, Nikolas",
+      "type": "Other"
+    },
+    {
+      "name": "Beasley, Ben",
+      "type": "Other"
+    },
+    {
+      "name": "Soares Siqueira, Abel",
+      "orcid": "0000-0003-4451-281X",
+      "type": "Other"
+    },
+    {
+      "name": "Monperrus, Martin",
+      "type": "Other"
+    },
+    {
+      "name": "ots22",
+      "type": "Other"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Verhoeven, Stefan",
+      "orcid": "0000-0002-5821-2060",
+      "type": "Other"
+    }
+  ],
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",
       "name": "Spaaks, Jurriaan H.",
       "orcid": "0000-0002-7064-4069"
-    },
-    {
-      "affiliation": "Netherlands eScience Center",
-      "name": "Klaver, Tom"
-    },
-    {
-      "affiliation": "Netherlands eScience Center",
-      "name": "Verhoeven, Stefan",
-      "orcid": "0000-0002-5821-2060"
-    },
-    {
-      "affiliation": "Humboldt-Universität zu Berlin",
-      "name": "Druskat, Stephan",
-      "orcid": "0000-0003-4925-7248"
-    },
-    {
-      "affiliation": "University of Oslo",
-      "name": "Leoncio Netto, Waldir"
     }
   ],
   "description": "Command line program to validate and convert CITATION.cff files.",
@@ -40,6 +71,29 @@
     "id": "Apache-2.0"
   },
   "publication_date": "2021-09-22",
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.1162057",
+      "relation": "isPartOf",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.5281/zenodo.5521767",
+      "relation": "isIdenticalTo",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/citation-file-format/cffconvert",
+      "relation": "isSupplementedBy",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://pypi.org/project/cffconvert",
+      "relation": "isSupplementedBy",
+      "scheme": "url"
+    }
+  ],
   "title": "cffconvert",
-  "version": "2.0.0"
+  "upload_type": "software",
+  "version": "3.0.0a0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# Unreleased
+# 3.0.0 (Unreleased)
 
 - added pre-commit git hook with id `validate-cff`
 - entity authors get exported as `Organization` when converting to `schema.org` or `codemeta` (was `Person`)
-- CFF key `name` takes precedence over `alias` when converting entity authors  
+- CFF key `name` takes precedence over `alias` when converting entity authors (was the other way around)  
 
 # 2.0.0
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,33 +1,58 @@
 abstract: Command line program to validate and convert CITATION.cff files.
 authors:
   - affiliation: Netherlands eScience Center
+    alias: jspaaks
     family-names: Spaaks
     given-names: Jurriaan H.
     orcid: https://orcid.org/0000-0002-7064-4069
-  - affiliation: Netherlands eScience Center
-    family-names: Klaver
-    given-names: Tom
-  - affiliation: Netherlands eScience Center
-    family-names: Verhoeven
-    given-names: Stefan
-    orcid: https://orcid.org/0000-0002-5821-2060
-  - affiliation: Humboldt-Universität zu Berlin
-    family-names: Druskat
-    given-names: Stephan
-    orcid: https://orcid.org/0000-0003-4925-7248
+contributors:
   - affiliation: University of Oslo
+    alias: wleoncio
     family-names: Leoncio
     given-names: Waldir
     name-suffix: Netto
-cff-version: 1.2.0
+  - affiliation: Humboldt-Universität zu Berlin
+    alias: sdruskat
+    family-names: Druskat
+    given-names: Stephan
+    orcid: https://orcid.org/0000-0003-4925-7248
+  - affiliation: Netherlands eScience Center
+    alias: Tommos0
+    family-names: Klaver
+    given-names: Tom
+  - alias: zmoon
+    family-names: Moon
+    given-names: Zachary
+  - alias: nialov
+    family-names: Ovaskainen
+    given-names: Nikolas
+  - alias: musicinmybrain
+    family-names: Beasley
+    given-names: Ben
+  - alias: abelsiqueira
+    family-names: Soares Siqueira
+    given-names: Abel
+    orcid: https://orcid.org/0000-0003-4451-281X
+  - alias: monperrus
+    family-names: Monperrus
+    given-names: Martin
+  - alias: ots22
+  - affiliation: Netherlands eScience Center
+    alias: sverhoeven
+    family-names: Verhoeven
+    given-names: Stefan
+    orcid: https://orcid.org/0000-0002-5821-2060
+cff-version: 1.3.0
 date-released: 2021-09-22
 identifiers:
   - type: doi
     value: 10.5281/zenodo.1162057
     description: Persistent identifier for all versions of cffconvert
+    relation: isPartOf
   - type: doi
     value: 10.5281/zenodo.5521767
     description: Persistent identifier for this version of cffconvert
+    relation: isIdenticalTo
   - type: url
     value: https://github.com/citation-file-format/cffconvert
     description: URL to the GitHub repository for cffconvert
@@ -50,7 +75,7 @@ repository-artifact: https://pypi.org/project/cffconvert
 repository-code: https://github.com/citation-file-format/cffconvert
 title: cffconvert
 type: software
-version: 2.0.0
+version: 3.0.0a0
 references:
   - authors:
       - affiliation: Netherlands eScience Center

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.9-alpine
+FROM python:3.18-alpine
 RUN apk --no-cache add build-base
-RUN python3 -m pip install cffconvert==2.0.0
+RUN python3 -m pip install cffconvert==3.0.0a0
 WORKDIR /app
 ENTRYPOINT ["cffconvert"]

--- a/README.dev.md
+++ b/README.dev.md
@@ -144,7 +144,7 @@ pre-commit install
 There are various source keys in CFF that can be used to convert to a target format. The code uses a pattern of first
 identifiying what information is present, then summarizing this as a key, then using that key to retrieve a method which 
 is tailored only to that specific combination of source keys. As an example of this mapping, see the setup in
-https://github.com/citation-file-format/cffconvert/blob/2.0.0/cffconvert/behavior_shared/schemaorg_author_shared.py
+https://github.com/citation-file-format/cffconvert/blob/3.0.0a0/cffconvert/behavior_shared/schemaorg_author_shared.py
 
 Source keys:
 
@@ -439,8 +439,8 @@ The table below lists how the key name is constructed based what information was
 ### Building the docker image
 
 ```shell
-# (requires 2.0.0 to be downloadable from PyPI)
-docker build --tag cffconvert:2.0.0 .
+# (requires 3.0.0a0 to be downloadable from PyPI)
+docker build --tag cffconvert:3.0.0a0 .
 docker build --tag cffconvert:latest .
 ```
 
@@ -464,10 +464,10 @@ docker logout
 docker login
 
 # re-tag existing images
-docker tag cffconvert:2.0.0 citationcff/cffconvert:2.0.0
+docker tag cffconvert:3.0.0a0 citationcff/cffconvert:3.0.0a0
 docker tag cffconvert:latest citationcff/cffconvert:latest
 
 # publish
-docker push citationcff/cffconvert:2.0.0
+docker push citationcff/cffconvert:3.0.0a0
 docker push citationcff/cffconvert:latest
 ```

--- a/docs/alternative-install-options.md
+++ b/docs/alternative-install-options.md
@@ -78,7 +78,7 @@ Build the Docker container
 
 ```shell
 cd <project root>
-docker build --tag cffconvert:2.0.0 .
+docker build --tag cffconvert:3.0.0a0 .
 docker build --tag cffconvert:latest .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ license = {text = "Apache Software License"}
 name = "cffconvert"
 readme = "README.md"
 requires-python = ">=3.7"
-version = "2.0.0"
+version = "3.0.0a0"
 
 [project.urls]
 Changelog = "https://github.com/citation-file-format/cffconvert/blob/main/CHANGELOG.md"

--- a/src/cffconvert/version.py
+++ b/src/cffconvert/version.py
@@ -1,4 +1,4 @@
 # from https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined
 # -in-setup-py-setuptools-in-my-package#answer-24517154
 
-__version__ = "2.0.0"
+__version__ = "3.0.0a0"

--- a/tests/cff_1_0_3/a/test_cli.py
+++ b/tests/cff_1_0_3/a/test_cli.py
@@ -31,7 +31,7 @@ def test_printing_of_version():
     with runner.isolated_filesystem():
         result = runner.invoke(cffconvert_cli, ["--version"])
     assert result.exit_code == 0
-    assert result.output == "2.0.0\n"
+    assert result.output == "3.0.0a0\n"
 
 
 def test_printing_on_stdout_as_bibtex():

--- a/tests/cff_1_1_0/a/test_cli.py
+++ b/tests/cff_1_1_0/a/test_cli.py
@@ -30,7 +30,7 @@ def test_printing_of_version():
     with runner.isolated_filesystem():
         result = runner.invoke(cffconvert_cli, ["--version"])
     assert result.exit_code == 0
-    assert result.output == "2.0.0\n"
+    assert result.output == "3.0.0a0\n"
 
 
 def test_printing_on_stdout_as_bibtex():

--- a/tests/cff_1_2_0/identifiers/D_/test_cli.py
+++ b/tests/cff_1_2_0/identifiers/D_/test_cli.py
@@ -30,7 +30,7 @@ def test_printing_of_version():
     with runner.isolated_filesystem():
         result = runner.invoke(cffconvert_cli, ["--version"])
     assert result.exit_code == 0
-    assert result.output == "2.0.0\n"
+    assert result.output == "3.0.0a0\n"
 
 
 def test_printing_on_stdout_as_bibtex():

--- a/tests/cff_1_3_0/identifiers/sources/D_/test_cli.py
+++ b/tests/cff_1_3_0/identifiers/sources/D_/test_cli.py
@@ -30,7 +30,7 @@ def test_printing_of_version():
     with runner.isolated_filesystem():
         result = runner.invoke(cffconvert_cli, ["--version"])
     assert result.exit_code == 0
-    assert result.output == "2.0.0\n"
+    assert result.output == "3.0.0a0\n"
 
 
 def test_printing_on_stdout_as_bibtex():


### PR DESCRIPTION
- bumped cffconvert version to 3.0.0a0
- `.zenodo.json`, `CITATION.cff`: split the authors into author and contributors; exported the identifiers, both using preliminary functionality based on preliminary schema
- updated alpine image version in Dockerfile
- updated other instances of version number