### PR TITLE
testing order bug

### DIFF
--- a/src/cffconvert/cff_1_1_x/citation.py
+++ b/src/cffconvert/cff_1_1_x/citation.py
@@ -1,5 +1,6 @@
 import os
 from pykwalify.core import Core
+from ruamel.yaml import SafeConstructor
 from ruamel.yaml import YAML
 from cffconvert.cff_1_1_x.apalike import ApalikeObject
 from cffconvert.cff_1_1_x.bibtex import BibtexObject
@@ -30,9 +31,24 @@ class Citation_1_1_x(Contract):  # noqa
             return YAML(typ="safe").load(fid.read())
 
     def _parse(self):
-        cffobj = YAML(typ="safe").load(self.cffstr)
+        # instantiate the YAML module:
+        yaml = YAML(typ="safe")
+
+        # store the current value of the timestamp parser
+        tmp = yaml.constructor.yaml_constructors.get("tag:yaml.org,2002:timestamp")
+
+        # Configure YAML to load timestamps as timestamps:
+        yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = SafeConstructor.construct_yaml_timestamp
+
+        try:
+            cffobj = yaml.load(self.cffstr)
+        finally:
+            # restore the old value
+            yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = tmp
+
         if not isinstance(cffobj, dict):
             raise ValueError("Provided CITATION.cff does not seem valid YAML.")
+
         return cffobj
 
     def as_apalike(self):

--- a/src/cffconvert/cff_1_2_x/citation.py
+++ b/src/cffconvert/cff_1_2_x/citation.py
@@ -35,11 +35,18 @@ class Citation_1_2_x(Contract):  # noqa
         # instantiate the YAML module:
         yaml = YAML(typ="safe")
 
-        # while loading, convert timestamps to string
+        # store the current value of the timestamp parser
+        tmp = yaml.constructor.yaml_constructors.get("tag:yaml.org,2002:timestamp")
+
+        # Configure YAML to load timestamps as strings:
         yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = \
             yaml.constructor.yaml_constructors["tag:yaml.org,2002:str"]
 
-        cffobj = yaml.load(self.cffstr)
+        try:
+            cffobj = yaml.load(self.cffstr)
+        finally:
+            # restore the old value
+            yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = tmp
 
         if not isinstance(cffobj, dict):
             raise ValueError("Provided CITATION.cff does not seem valid YAML.")

--- a/src/cffconvert/cff_1_2_x/citation.py
+++ b/src/cffconvert/cff_1_2_x/citation.py
@@ -2,8 +2,8 @@ import json
 import os
 import jsonschema
 from jsonschema.exceptions import ValidationError
-from ruamel.yaml import YAML
 from ruamel.yaml import SafeConstructor
+from ruamel.yaml import YAML
 from cffconvert.cff_1_2_x.apalike import ApalikeObject
 from cffconvert.cff_1_2_x.bibtex import BibtexObject
 from cffconvert.cff_1_2_x.codemeta import CodemetaObject

--- a/src/cffconvert/cff_1_2_x/citation.py
+++ b/src/cffconvert/cff_1_2_x/citation.py
@@ -3,6 +3,7 @@ import os
 import jsonschema
 from jsonschema.exceptions import ValidationError
 from ruamel.yaml import YAML
+from ruamel.yaml import SafeConstructor
 from cffconvert.cff_1_2_x.apalike import ApalikeObject
 from cffconvert.cff_1_2_x.bibtex import BibtexObject
 from cffconvert.cff_1_2_x.codemeta import CodemetaObject
@@ -39,8 +40,7 @@ class Citation_1_2_x(Contract):  # noqa
         tmp = yaml.constructor.yaml_constructors.get("tag:yaml.org,2002:timestamp")
 
         # Configure YAML to load timestamps as strings:
-        yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = \
-            yaml.constructor.yaml_constructors["tag:yaml.org,2002:str"]
+        yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = SafeConstructor.construct_yaml_str
 
         try:
             cffobj = yaml.load(self.cffstr)

--- a/src/cffconvert/cff_1_3_x/citation.py
+++ b/src/cffconvert/cff_1_3_x/citation.py
@@ -35,11 +35,18 @@ class Citation_1_3_x(Contract):  # noqa
         # instantiate the YAML module:
         yaml = YAML(typ="safe")
 
-        # while loading, convert timestamps to string
+        # store the current value of the timestamp parser
+        tmp = yaml.constructor.yaml_constructors.get("tag:yaml.org,2002:timestamp")
+
+        # Configure YAML to load timestamps as strings:
         yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = \
             yaml.constructor.yaml_constructors["tag:yaml.org,2002:str"]
 
-        cffobj = yaml.load(self.cffstr)
+        try:
+            cffobj = yaml.load(self.cffstr)
+        finally:
+            # restore the old value
+            yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = tmp
 
         if not isinstance(cffobj, dict):
             raise ValueError("Provided CITATION.cff does not seem valid YAML.")

--- a/src/cffconvert/cff_1_3_x/citation.py
+++ b/src/cffconvert/cff_1_3_x/citation.py
@@ -3,6 +3,7 @@ import os
 import jsonschema
 from jsonschema.exceptions import ValidationError
 from ruamel.yaml import YAML
+from ruamel.yaml import SafeConstructor
 from cffconvert.cff_1_3_x.apalike import ApalikeObject
 from cffconvert.cff_1_3_x.bibtex import BibtexObject
 from cffconvert.cff_1_3_x.codemeta import CodemetaObject
@@ -39,8 +40,7 @@ class Citation_1_3_x(Contract):  # noqa
         tmp = yaml.constructor.yaml_constructors.get("tag:yaml.org,2002:timestamp")
 
         # Configure YAML to load timestamps as strings:
-        yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = \
-            yaml.constructor.yaml_constructors["tag:yaml.org,2002:str"]
+        yaml.constructor.yaml_constructors["tag:yaml.org,2002:timestamp"] = SafeConstructor.construct_yaml_str
 
         try:
             cffobj = yaml.load(self.cffstr)

--- a/src/cffconvert/cff_1_3_x/citation.py
+++ b/src/cffconvert/cff_1_3_x/citation.py
@@ -2,8 +2,8 @@ import json
 import os
 import jsonschema
 from jsonschema.exceptions import ValidationError
-from ruamel.yaml import YAML
 from ruamel.yaml import SafeConstructor
+from ruamel.yaml import YAML
 from cffconvert.cff_1_3_x.apalike import ApalikeObject
 from cffconvert.cff_1_3_x.bibtex import BibtexObject
 from cffconvert.cff_1_3_x.codemeta import CodemetaObject


### PR DESCRIPTION
This PR changes the way yaml text is parsed. It appears that ruamel.yaml persists some of its configuration, see

- #343

This PR stores the timestamp parser that is present before we change anything, and restores it afterwards. Additionally it configures the parser to read timestamps as timestamp under cff-version 1.0.x and 1.1.x and as string under cff-version 1.2.x and 1.3.x, but now using ruamel.yaml's own constructor methods from `YAML.SafeConstructor`, as opposed to whatever it finds was previously configured as a parser.