### PR TITLE
bibtex name protection

### DIFF
--- a/src/cffconvert/lib/cff_1_x_x/authors/bibtex.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/bibtex.py
@@ -138,7 +138,7 @@ class BibtexAuthor(BaseAuthor):
         }
 
     def _from_alias(self):
-        return self._author.get("alias")
+        return "{" + self._author.get("alias") + "}"
 
     def _from_given_and_last(self):
         return self._from_last() + ", " + self._from_given()
@@ -155,7 +155,7 @@ class BibtexAuthor(BaseAuthor):
         return " ".join([n for n in nameparts if n is not None])
 
     def _from_name(self):
-        return self._author.get("name")
+        return "{" + self._author.get("name") + "}"
 
     def as_string(self):
         key = self._get_key()

--- a/tests/cli/cff_1_2_0/bibtex.bib
+++ b/tests/cli/cff_1_2_0/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-doi},
 title = {Test title}
 }

--- a/tests/cli/cff_1_3_0/bibtex.bib
+++ b/tests/cli/cff_1_3_0/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-doi},
 title = {Test title}
 }

--- a/tests/lib/cff_1_1_0/e/bibtex.bib
+++ b/tests/lib/cff_1_1_0/e/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and {mysteryauthor}},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cffconvert},

--- a/tests/lib/cff_1_1_0/e/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/e/test_bibtex_object.py
@@ -24,7 +24,8 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor}"
+        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and " + \
+            "Klaver, Tom and {mysteryauthor}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/g/bibtex.bib
+++ b/tests/lib/cff_1_1_0/g/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and {mysteryauthor}},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cffconvert},

--- a/tests/lib/cff_1_1_0/g/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/g/test_bibtex_object.py
@@ -24,7 +24,8 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor}"
+        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and " +\
+            "Klaver, Tom and {mysteryauthor}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/bibtex.bib
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The soccer team members},
+author = {{The soccer team members}},
 title = {the title}
 }

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The soccer team members}"
+        assert bibtex_object().add_author().author == "author = {{The soccer team members}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/___N___/bibtex.bib
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The soccer team members},
+author = {{The soccer team members}},
 title = {the title}
 }

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The soccer team members}"
+        assert bibtex_object().add_author().author == "author = {{The soccer team members}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/DI/bibtex.bib
+++ b/tests/lib/cff_1_2_0/identifiers/DI/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-identifiers},
 title = {Test title}
 }

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/bibtex.bib
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/some-doi},
 title = {Test title}
 }

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/D_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/identifiers/D_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-doi},
 title = {Test title}
 }

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/_I/bibtex.bib
+++ b/tests/lib/cff_1_2_0/identifiers/_I/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-identifiers},
 title = {Test title}
 }

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/__/bibtex.bib
+++ b/tests/lib/cff_1_2_0/identifiers/__/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title}
 }

--- a/tests/lib/cff_1_2_0/identifiers/__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IRACU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IRACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IRAC_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IRA_U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IRA__/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IRA__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IR_CU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IR_C_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IR__U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IR__U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/IR___/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/IR___/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/IR___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I_ACU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I_AC_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I_A_U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I_A__/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I_A__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I__CU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I__CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I__C_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I__C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I___U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I___U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I___U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/I____/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/I____/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_2_0/urls/I____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_RACU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_RACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_RAC_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_RA_U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_RA__/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_RA__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository}
 }

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_R_CU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_R_C_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_R__U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_R__U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_R___/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_R___/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository}
 }

--- a/tests/lib/cff_1_2_0/urls/_R___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/__ACU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/__ACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/__AC_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/__AC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/__A_U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/__A_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/__A__/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/__A__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-artifact}
 }

--- a/tests/lib/cff_1_2_0/urls/__A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/___CU/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/___CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/___CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/___C_/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/___C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_2_0/urls/___C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/____U/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/____U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_2_0/urls/____U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/urls/_____/bibtex.bib
+++ b/tests/lib/cff_1_2_0/urls/_____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title}
 }

--- a/tests/lib/cff_1_2_0/urls/_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/bibtex.bib
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The soccer team members},
+author = {{The soccer team members}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The soccer team members}"
+        assert bibtex_object().add_author().author == "author = {{The soccer team members}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/__A____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/.zenodo.json
@@ -1,0 +1,9 @@
+{
+  "creators": [
+    {
+      "name": "Rafa"
+    }
+  ],
+  "title": "the title",
+  "upload_type": "software"
+}

--- a/tests/lib/cff_1_3_0/authors/one/__A____/CITATION.cff
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/CITATION.cff
@@ -1,0 +1,5 @@
+authors:
+  - alias: Rafa
+cff-version: "1.3.0"
+message: "test of author inputs"
+title: the title

--- a/tests/lib/cff_1_3_0/authors/one/__A____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/apalike.txt
@@ -1,0 +1,1 @@
+Rafa the title

--- a/tests/lib/cff_1_3_0/authors/one/__A____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {{Rafa}},
+title = {the title}
+}

--- a/tests/lib/cff_1_3_0/authors/one/__A____/endnote.enw
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/endnote.enw
@@ -1,0 +1,3 @@
+%0 Generic
+%A Rafa
+%T the title

--- a/tests/lib/cff_1_3_0/authors/one/__A____/ris.txt
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/ris.txt
@@ -1,0 +1,4 @@
+TY  - GEN
+AU  - Rafa
+TI  - the title
+ER

--- a/tests/lib/cff_1_3_0/authors/one/__A____/schemaorg.json
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/schemaorg.json
@@ -1,0 +1,11 @@
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  "author": [
+    {
+      "@type": "Person",
+      "alternateName": "Rafa"
+    }
+  ],
+  "name": "the title"
+}

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
+from tests.contracts.apalike_object import Contract
+
+
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.apalike
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == "Rafa"
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi is None
+
+    def test_title(self):
+        assert apalike_object().add_title().title == "the title"
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_version(self):
+        assert apalike_object().add_version().version is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_bibtex_object.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
+from tests.contracts.bibtex_object import Contract
+
+
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.bibtex
+class TestBibtexObject(Contract):
+
+    def test_as_string(self):
+        actual_bibtex = bibtex_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_author(self):
+        assert bibtex_object().add_author().author == "author = {{Rafa}}"
+
+    def test_check_cffobj(self):
+        bibtex_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert bibtex_object().add_doi().doi is None
+
+    def test_month(self):
+        assert bibtex_object().add_month().month is None
+
+    def test_title(self):
+        assert bibtex_object().add_title().title == "title = {the title}"
+
+    def test_url(self):
+        assert bibtex_object().add_url().url is None
+
+    def test_year(self):
+        assert bibtex_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_citation.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_citation.py
@@ -1,0 +1,17 @@
+import os
+from cffconvert.lib.citation import Citation
+
+
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffversion():
+    assert citation().cffversion == "1.3.0"
+
+
+def test_validate():
+    citation().validate(verbose=False)

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_endnote_object.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
+from tests.contracts.endnote_object import Contract
+
+
+def endnote_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return EndnoteObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.endnote
+class TestEndnoteObject(Contract):
+
+    def test_as_string(self):
+        actual_endnote = endnote_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_endnote = f.read()
+        assert actual_endnote == expected_endnote
+
+    def test_author(self):
+        assert endnote_object().add_author().author == "%A Rafa\n"
+
+    def test_check_cffobj(self):
+        endnote_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert endnote_object().add_doi().doi is None
+
+    def test_keyword(self):
+        assert endnote_object().add_keyword().keyword is None
+
+    def test_name(self):
+        assert endnote_object().add_name().name == "%T the title\n"
+
+    def test_url(self):
+        assert endnote_object().add_url().url is None
+
+    def test_year(self):
+        assert endnote_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_ris_object.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.ris import RisObject
+from tests.contracts.ris_object import Contract
+
+
+def ris_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return RisObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.ris
+class TestRisObject(Contract):
+
+    def test_abstract(self):
+        assert ris_object().add_abstract().abstract is None
+
+    def test_as_string(self):
+        actual_ris = ris_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "ris.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_ris = f.read()
+        assert actual_ris == expected_ris
+
+    def test_author(self):
+        assert ris_object().add_author().author == "AU  - Rafa\n"
+
+    def test_check_cffobj(self):
+        ris_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_date(self):
+        assert ris_object().add_date().date is None
+
+    def test_doi(self):
+        assert ris_object().add_doi().doi is None
+
+    def test_keywords(self):
+        assert ris_object().add_keywords().keywords is None
+
+    def test_title(self):
+        assert ris_object().add_title().title == "TI  - the title\n"
+
+    def test_url(self):
+        assert ris_object().add_url().url is None
+
+    def test_year(self):
+        assert ris_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_schemaorg_object.py
@@ -1,0 +1,67 @@
+import os
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
+from tests.contracts.schemaorg_object import Contract
+
+
+def schemaorg_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return SchemaorgObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.schemaorg
+class TestSchemaorgObject(Contract):
+
+    def test_as_string(self):
+        actual_schemaorg = schemaorg_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_schemaorg = f.read()
+        assert actual_schemaorg == expected_schemaorg
+
+    def test_author(self):
+        assert schemaorg_object().add_author().author == [{
+            "@type": "Person",
+            "alternateName": "Rafa"
+        }]
+
+    def test_check_cffobj(self):
+        schemaorg_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_code_repository(self):
+        assert schemaorg_object().add_urls().code_repository is None
+
+    def test_contributor(self):
+        assert schemaorg_object().add_contributor().contributor is None
+
+    def test_date_published(self):
+        assert schemaorg_object().add_date_published().date_published is None
+
+    def test_description(self):
+        assert schemaorg_object().add_description().description is None
+
+    def test_identifier(self):
+        assert schemaorg_object().add_identifier().identifier is None
+
+    def test_keywords(self):
+        assert schemaorg_object().add_keywords().keywords is None
+
+    def test_license(self):
+        assert schemaorg_object().add_license().license is None
+
+    def test_name(self):
+        assert schemaorg_object().add_name().name == "the title"
+
+    def test_upload_type(self):
+        assert schemaorg_object().add_type().type == "SoftwareSourceCode"
+
+    def test_url(self):
+        assert schemaorg_object().add_urls().url is None
+
+    def test_version(self):
+        assert schemaorg_object().add_version().version is None

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_zenodo_object.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
+from tests.contracts.zenodo_object import Contract
+
+
+def zenodo_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ZenodoObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.zenodo
+class TestZenodoObject(Contract):
+
+    def test_as_string(self):
+        actual_zenodo = zenodo_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_zenodo = f.read()
+        assert actual_zenodo == expected_zenodo
+
+    def test_contributors(self):
+        assert zenodo_object().add_contributors().contributors is None
+
+    def test_creators(self):
+        assert zenodo_object().add_creators().creators == [
+            {
+                "name": "Rafa"
+            }
+        ]
+
+    def test_check_cffobj(self):
+        zenodo_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_keywords(self):
+        assert zenodo_object().add_keywords().keywords is None
+
+    def test_license(self):
+        assert zenodo_object().add_license().license is None
+
+    def test_publication_date(self):
+        assert zenodo_object().add_publication_date().publication_date is None
+
+    def test_related_identifiers(self):
+        assert zenodo_object().add_related_identifiers().related_identifiers is None
+
+    def test_title(self):
+        assert zenodo_object().add_title().title == "the title"
+
+    def test_upload_type(self):
+        assert zenodo_object().add_upload_type().upload_type == "software"
+
+    def test_version(self):
+        assert zenodo_object().add_version().version is None

--- a/tests/lib/cff_1_3_0/authors/one/___N___/bibtex.bib
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The soccer team members},
+author = {{The soccer team members}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The soccer team members}"
+        assert bibtex_object().add_author().author == "author = {{The soccer team members}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/G______/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {The author},
+author = {{The author}},
 title = {the title}
 }

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {The author}"
+        assert bibtex_object().add_author().author == "author = {{The author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/bibtex.bib
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-identifiers},
 title = {Test title}
 }

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/bibtex.bib
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/some-doi},
 title = {Test title}
 }

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/bibtex.bib
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/somewhere}
 }

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-doi},
 title = {Test title}
 }

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/bibtex.bib
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 doi = {10.0000/from-identifiers},
 title = {Test title}
 }

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/bibtex.bib
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title}
 }

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_bibtex_object.py
@@ -24,7 +24,7 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IRACU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IRACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IRAC_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IRA_U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IRA__/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IRA__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IR_CU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IR_C_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IR__U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IR__U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/IR___/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/IR___/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/IR___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I_ACU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I_AC_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I_A_U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I_A__/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I_A__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I__CU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I__CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I__C_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I__C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I___U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I___U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I___U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/I____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/I____/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-identifiers}
 }

--- a/tests/lib/cff_1_3_0/urls/I____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_RACU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_RACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_RAC_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_RA_U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_RA__/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_RA__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository}
 }

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_R_CU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_R_C_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_R__U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_R__U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_R___/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_R___/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository}
 }

--- a/tests/lib/cff_1_3_0/urls/_R___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/__ACU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/__ACU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/__AC_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/__AC_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/__A_U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/__A_U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/__A__/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/__A__/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-artifact}
 }

--- a/tests/lib/cff_1_3_0/urls/__A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/___CU/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/___CU/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/___CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/___C_/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/___C_/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-repository-code}
 }

--- a/tests/lib/cff_1_3_0/urls/___C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/____U/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/____U/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title},
 url = {https://github.com/the-url-from-url}
 }

--- a/tests/lib/cff_1_3_0/urls/____U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/urls/_____/bibtex.bib
+++ b/tests/lib/cff_1_3_0/urls/_____/bibtex.bib
@@ -1,4 +1,4 @@
 @misc{YourReferenceHere,
-author = {Test author},
+author = {{Test author}},
 title = {Test title}
 }

--- a/tests/lib/cff_1_3_0/urls/_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_bibtex_object.py
@@ -17,7 +17,7 @@ def bibtex_object():
 class TestBibtexObject(Contract):
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Test author}"
+        assert bibtex_object().add_author().author == "author = {{Test author}}"
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()


### PR DESCRIPTION
Refs: 

- #156

This PR adds name protection for entity authors when converting to bibtex. This helps avoid abbreviating and capitalization changes when the bibtex string is used later on.