### PR TITLE
apalike author concatenation

### DIFF
--- a/src/cffconvert/lib/cff_1_0_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_0_x/apalike.py
@@ -15,7 +15,12 @@ class ApalikeObject(Shared):
         authors_cff = self.cffobj.get("authors", [])
         authors_apalike = [ApalikeAuthor(a).as_string() for a in authors_cff]
         authors_apalike_filtered = [a for a in authors_apalike if a is not None]
-        if len(authors_apalike_filtered) > 0:
+        n_authors = len(authors_apalike_filtered)
+        if n_authors > 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if n_authors == 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
+        if n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
         return self
 

--- a/src/cffconvert/lib/cff_1_1_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_1_x/apalike.py
@@ -13,7 +13,12 @@ class ApalikeObject(Shared):
         authors_cff = self.cffobj.get("authors", [])
         authors_apalike = [ApalikeAuthor(a).as_string() for a in authors_cff]
         authors_apalike_filtered = [a for a in authors_apalike if a is not None]
-        if len(authors_apalike_filtered) > 0:
+        n_authors = len(authors_apalike_filtered)
+        if n_authors > 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if n_authors == 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
+        if n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
         return self
 

--- a/src/cffconvert/lib/cff_1_2_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_2_x/apalike.py
@@ -13,7 +13,12 @@ class ApalikeObject(Shared):
         authors_cff = self.cffobj.get("authors", [])
         authors_apalike = [ApalikeAuthor(a).as_string() for a in authors_cff]
         authors_apalike_filtered = [a for a in authors_apalike if a is not None]
-        if len(authors_apalike_filtered) > 0:
+        n_authors = len(authors_apalike_filtered)
+        if n_authors > 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if n_authors == 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
+        if n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
         return self
 

--- a/src/cffconvert/lib/cff_1_3_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_3_x/apalike.py
@@ -13,7 +13,12 @@ class ApalikeObject(Shared):
         authors_cff = self.cffobj.get("authors", [])
         authors_apalike = [ApalikeAuthor(a).as_string() for a in authors_cff]
         authors_apalike_filtered = [a for a in authors_apalike if a is not None]
-        if len(authors_apalike_filtered) > 0:
+        n_authors = len(authors_apalike_filtered)
+        if n_authors > 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if n_authors == 2:
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
+        if n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
         return self
 

--- a/tests/cli/cff_1_0_3/apalike.txt
+++ b/tests/cli/cff_1_0_3/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/cli/cff_1_1_0/apalike.txt
+++ b/tests/cli/cff_1_1_0/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/a/apalike.txt
+++ b/tests/lib/cff_1_0_3/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/a/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/a/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/c/apalike.txt
+++ b/tests/lib/cff_1_0_3/c/apalike.txt
@@ -1,1 +1,1 @@
-Attema J., Diblen F. (2017). spot (version 0.1.0). DOI: 10.5281/zenodo.1003346 URL: https://github.com/NLeSC/spot
+Attema J. and Diblen F. (2017). spot (version 0.1.0). DOI: 10.5281/zenodo.1003346 URL: https://github.com/NLeSC/spot

--- a/tests/lib/cff_1_0_3/c/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/c/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Attema J., Diblen F."
+        assert apalike_object().add_author().author == "Attema J. and Diblen F."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/d/apalike.txt
+++ b/tests/lib/cff_1_0_3/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., Verhoeven S., Druskat S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H., Klaver T., Verhoeven S., and Druskat S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/d/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/d/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., Verhoeven S., Druskat S."
+        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., Verhoeven S., and Druskat S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/e/apalike.txt
+++ b/tests/lib/cff_1_0_3/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., Verhoeven S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H., Klaver T., and Verhoeven S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/e/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/e/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., Verhoeven S."
+        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and Verhoeven S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/a/apalike.txt
+++ b/tests/lib/cff_1_1_0/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/a/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/a/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/b/apalike.txt
+++ b/tests/lib/cff_1_1_0/b/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/b/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/b/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/c/apalike.txt
+++ b/tests/lib/cff_1_1_0/c/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/c/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/c/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/d/apalike.txt
+++ b/tests/lib/cff_1_1_0/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/d/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/d/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/e/apalike.txt
+++ b/tests/lib/cff_1_1_0/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., mysteryauthor (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H., Klaver T., and mysteryauthor (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/e/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/e/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., mysteryauthor"
+        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor"
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/f/apalike.txt
+++ b/tests/lib/cff_1_1_0/f/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/f/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/f/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/g/apalike.txt
+++ b/tests/lib/cff_1_1_0/g/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., mysteryauthor (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H., Klaver T., and mysteryauthor (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/g/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/g/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., mysteryauthor"
+        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor"
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/h/apalike.txt
+++ b/tests/lib/cff_1_1_0/h/apalike.txt
@@ -1,1 +1,1 @@
-Van Zandt S., van Zandt S. (2018). cffconvert (version 1.0.0).
+Van Zandt S. and van Zandt S. (2018). cffconvert (version 1.0.0).

--- a/tests/lib/cff_1_1_0/h/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/h/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Van Zandt S., van Zandt S."
+        assert apalike_object().add_author().author == "Van Zandt S. and van Zandt S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R., dos Santos Aveiro C.R. the title
+van der Vaart III R. and dos Santos Aveiro C.R. the title

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R., dos Santos Aveiro C.R."
+        assert apalike_object().add_author().author == "van der Vaart III R. and dos Santos Aveiro C.R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R., dos Santos Aveiro C.R. the title
+van der Vaart III R. and dos Santos Aveiro C.R. the title

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
@@ -24,7 +24,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R., dos Santos Aveiro C.R."
+        assert apalike_object().add_author().author == "van der Vaart III R. and dos Santos Aveiro C.R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()


### PR DESCRIPTION
refs:

- #226

This PR updates how author names are concatenated when exporting to apalike, and depending on the number of authors:

- 1 author: `Authorone, I.`
- 2 authors: `Authorone, I. and Authortwo, I.`
- 2+ authors: `Authorone, I., Authortwo, I., ..., and Authorlast, I.`

where `I` is initial