### PR TITLE
Add Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Hi! I noticed that CI is throwing deprecation warnings due to out-of-date action versions (like `actions/checkout@v2` -- [recent example](https://github.com/citation-file-format/cffconvert/actions/runs/6720385692)).

Rather than submitting a PR to update the versions once, this PR introduces a Dependabot configuration that will submit a PR to update action versions (if needed) once each month.

If this merges, Dependabot will immediately submit a PR to address the out-of-date versions and will continue to keep the actions up-to-date in perpetuity.