### PR TITLE
Update alternative install options

### DIFF
--- a/docs/alternative-install-options.md
+++ b/docs/alternative-install-options.md
@@ -86,3 +86,20 @@ cd <where your CITATION.cff is>
 docker run --rm -ti -v ${PWD}:/app cffconvert
 ```
 
+### Platform-specific packages
+
+#### Alpine Linux
+
+To install cffconvert on Alpine Linux, use:
+
+```sh
+apk add cffconvert
+```
+
+#### Fedora Linux
+
+To install cffconvert on Fedora Linux, use:
+
+```sh
+dnf install cffconvert
+```


### PR DESCRIPTION
This pull request proposes a minor update of alternative install options document. Since **cffconvert** package is also available in various Linux distributions and some users prefer installing packages using distro-specific package managers, I recommend adding another section to this document. I am the maintainer of this package for Alpine Linux and Fedora.