### PR TITLE
updated version range for jsonschema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "requests >=2.20, <3",
     "ruamel.yaml >=0.16.0",
     "pykwalify >=1.6",
-    "jsonschema >=3.0, <5",
+    "jsonschema >=4.18.0, <5",
 ]
 description = "Command line program to validate and convert CITATION.cff files."
 keywords = [


### PR DESCRIPTION
Refs:

- PR #281

Description

raised lower limit of `jsonschema` version range to minimum supported version on py38
