### PR TITLE
Set `resource_type` for some `related_identifers` to  `software` in Zenodo backend

### DIFF
--- a/src/cffconvert/lib/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_x_x/zenodo.py
@@ -123,11 +123,15 @@ class ZenodoObjectShared:
             if url is None or url in seen:
                 # url not available or seen already
                 continue
-            related_identifiers.append({
+            identifier_dict = {
                 "identifier": url,
                 "relation": "isSupplementedBy",
                 "scheme": "url"
-            })
+            }
+            if cffkey in ["repository-artifact", "repository-code"]:
+                # add resource_type
+                identifier_dict["resource_type"] = "software"
+            related_identifiers.append(identifier_dict)
             seen.append(url)
         self.related_identifiers = related_identifiers if len(related_identifiers) > 0 else None
         return self

--- a/tests/cli/cff_1_0_3/.zenodo.json
+++ b/tests/cli/cff_1_0_3/.zenodo.json
@@ -28,6 +28,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/cli/cff_1_1_0/.zenodo.json
+++ b/tests/cli/cff_1_1_0/.zenodo.json
@@ -28,6 +28,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_0_3/a/.zenodo.json
+++ b/tests/lib/cff_1_0_3/a/.zenodo.json
@@ -28,6 +28,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_0_3/a/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/a/test_zenodo_object.py
@@ -62,6 +62,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",            
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_0_3/c/.zenodo.json
+++ b/tests/lib/cff_1_0_3/c/.zenodo.json
@@ -29,6 +29,7 @@
     {
       "identifier": "https://github.com/NLeSC/spot",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_0_3/c/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/c/test_zenodo_object.py
@@ -68,6 +68,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/NLeSC/spot",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_0_3/d/.zenodo.json
+++ b/tests/lib/cff_1_0_3/d/.zenodo.json
@@ -37,6 +37,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_0_3/d/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/d/test_zenodo_object.py
@@ -71,6 +71,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",            
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_0_3/e/.zenodo.json
+++ b/tests/lib/cff_1_0_3/e/.zenodo.json
@@ -32,6 +32,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_0_3/e/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/e/test_zenodo_object.py
@@ -66,6 +66,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_1_0/a/.zenodo.json
+++ b/tests/lib/cff_1_1_0/a/.zenodo.json
@@ -28,6 +28,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_1_0/a/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/a/test_zenodo_object.py
@@ -62,6 +62,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",            
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_1_0/b/.zenodo.json
+++ b/tests/lib/cff_1_1_0/b/.zenodo.json
@@ -28,6 +28,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_1_0/b/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/b/test_zenodo_object.py
@@ -62,6 +62,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_1_0/c/.zenodo.json
+++ b/tests/lib/cff_1_1_0/c/.zenodo.json
@@ -33,6 +33,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_1_0/c/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/c/test_zenodo_object.py
@@ -66,6 +66,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_1_0/d/.zenodo.json
+++ b/tests/lib/cff_1_1_0/d/.zenodo.json
@@ -33,6 +33,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_1_0/d/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/d/test_zenodo_object.py
@@ -66,6 +66,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_1_0/e/.zenodo.json
+++ b/tests/lib/cff_1_1_0/e/.zenodo.json
@@ -36,6 +36,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_1_0/e/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/e/test_zenodo_object.py
@@ -69,6 +69,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_1_0/f/.zenodo.json
+++ b/tests/lib/cff_1_1_0/f/.zenodo.json
@@ -33,6 +33,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_1_0/f/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/f/test_zenodo_object.py
@@ -66,6 +66,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_1_0/g/.zenodo.json
+++ b/tests/lib/cff_1_1_0/g/.zenodo.json
@@ -37,6 +37,7 @@
     {
       "identifier": "https://github.com/citation-file-format/cffconvert",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_1_0/g/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/g/test_zenodo_object.py
@@ -70,6 +70,7 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/citation-file-format/cffconvert",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 

--- a/tests/lib/cff_1_2_0/urls/IRACU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IRACU/.zenodo.json
@@ -18,11 +18,13 @@
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     },
     {

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_zenodo_object.py
@@ -59,10 +59,12 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-url",

--- a/tests/lib/cff_1_2_0/urls/IRAC_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/.zenodo.json
@@ -18,11 +18,13 @@
     {
       "identifier": "https://github.com/the-url-from-repository-artifact",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     },
     {
       "identifier": "https://github.com/the-url-from-repository-code",
       "relation": "isSupplementedBy",
+      "resource_type": "software",
       "scheme": "url"
     }
   ],

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
@@ -59,10 +59,12 @@ class TestZenodoObject(Contract):
         }, {
             "identifier": "https://github.com/the-url-from-repository-artifact",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }, {
             "identifier": "https://github.com/the-url-from-repository-code",
             "relation": "isSupplementedBy",
+            "resource_type": "software",
             "scheme": "url"
         }]
 


### PR DESCRIPTION
According to the CFF Schema: https://github.com/citation-file-format/citation-file-format/blob/develop/schema-guide.md#repository-artifact the two keys:

* `repository-code`
* `repository-artifact`

seem to be intended for software, so this PR adds the `resource_type` to be `software` in the Zenodo `related_identifiers` to provide more metadata upstream.