### PR TITLE
handle `message` as an `additional_descriptions`

### DIFF
--- a/src/cffconvert/lib/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_x_x/zenodo.py
@@ -11,6 +11,7 @@ class ZenodoObjectShared:
         self.contributors = None
         self.creators = None
         self.description = None
+        self.additional_descriptions = None
         self.keywords = None
         self.license = None
         self.publication_date = None
@@ -30,6 +31,7 @@ class ZenodoObjectShared:
             "contributors": self.contributors,
             "creators": self.creators,
             "description": self.description,
+            "additional_descriptions": self.additional_descriptions,
             "keywords": self.keywords,
             "license": self.license,
             "publication_date": self.publication_date,
@@ -45,6 +47,7 @@ class ZenodoObjectShared:
         self.add_contributors()        \
             .add_creators()            \
             .add_description()         \
+            .add_additional_descriptions()         \
             .add_keywords()            \
             .add_license()             \
             .add_publication_date()    \
@@ -66,6 +69,11 @@ class ZenodoObjectShared:
         self.description = self.cffobj.get("abstract")
         return self
 
+    def add_additional_descriptions(self):
+        if "message" in self.cffobj:
+            self.additional_descriptions = { "type": { "id": "notes"} , "description": self.cffobj.get("message") }
+        return self
+    
     def add_keywords(self):
         self.keywords = self.cffobj.get("keywords")
         return self

--- a/tests/cli/cff_1_0_3/.zenodo.json
+++ b/tests/cli/cff_1_0_3/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/cli/cff_1_1_0/.zenodo.json
+++ b/tests/cli/cff_1_1_0/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/cli/cff_1_2_0/.zenodo.json
+++ b/tests/cli/cff_1_2_0/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/cli/cff_1_3_0/.zenodo.json
+++ b/tests/cli/cff_1_3_0/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_0_3/a/.zenodo.json
+++ b/tests/lib/cff_1_0_3/a/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_0_3/b/.zenodo.json
+++ b/tests/lib/cff_1_0_3/b/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Example data from the CITATION.cff spec 1.0.3",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Fernández de Córdoba Jr., Gonzalo"

--- a/tests/lib/cff_1_0_3/c/.zenodo.json
+++ b/tests/lib/cff_1_0_3/c/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_0_3/d/.zenodo.json
+++ b/tests/lib/cff_1_0_3/d/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_0_3/e/.zenodo.json
+++ b/tests/lib/cff_1_0_3/e/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/a/.zenodo.json
+++ b/tests/lib/cff_1_1_0/a/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/b/.zenodo.json
+++ b/tests/lib/cff_1_1_0/b/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/c/.zenodo.json
+++ b/tests/lib/cff_1_1_0/c/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/d/.zenodo.json
+++ b/tests/lib/cff_1_1_0/d/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/e/.zenodo.json
+++ b/tests/lib/cff_1_1_0/e/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/f/.zenodo.json
+++ b/tests/lib/cff_1_1_0/f/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/g/.zenodo.json
+++ b/tests/lib/cff_1_1_0/g/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_1_0/h/.zenodo.json
+++ b/tests/lib/cff_1_1_0/h/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "If you use this software, please cite it using these metadata.",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Springsteen",

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III, Rafael"

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III, Rafael"

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Rafael"

--- a/tests/lib/cff_1_2_0/authors/one/G______/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/G______/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Rafael"

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III"

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III"

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The soccer team members"

--- a/tests/lib/cff_1_2_0/authors/one/___N___/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The soccer team members"

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III, Rafael"

--- a/tests/lib/cff_1_2_0/identifiers/DI/.zenodo.json
+++ b/tests/lib/cff_1_2_0/identifiers/DI/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/.zenodo.json
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/identifiers/D_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/identifiers/D_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/identifiers/_I/.zenodo.json
+++ b/tests/lib/cff_1_2_0/identifiers/_I/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/identifiers/__/.zenodo.json
+++ b/tests/lib/cff_1_2_0/identifiers/__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/types/dataset/.zenodo.json
+++ b/tests/lib/cff_1_2_0/types/dataset/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "The message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The name"

--- a/tests/lib/cff_1_2_0/types/none/.zenodo.json
+++ b/tests/lib/cff_1_2_0/types/none/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "The message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The name"

--- a/tests/lib/cff_1_2_0/types/software/.zenodo.json
+++ b/tests/lib/cff_1_2_0/types/software/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "The message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The name"

--- a/tests/lib/cff_1_2_0/urls/IRACU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IRACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/IRAC_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/IRA_U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/IRA__/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IRA__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/IR_CU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/IR_C_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/IR__U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IR__U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/IR___/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/IR___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I_ACU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I_AC_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I_A_U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I_A__/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I_A__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I__CU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I__CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I__C_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I__C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I___U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I___U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/I____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/I____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_RACU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_RACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_RAC_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_RA_U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_RA__/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_RA__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_R_CU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_R_C_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_R__U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_R__U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_R___/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_R___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/__ACU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/__ACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/__AC_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/__AC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/__A_U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/__A_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/__A__/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/__A__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/___CU/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/___CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/___C_/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/___C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/____U/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/____U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_2_0/urls/_____/.zenodo.json
+++ b/tests/lib/cff_1_2_0/urls/_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III, Rafael"

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III, Rafael"

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Rafael"

--- a/tests/lib/cff_1_3_0/authors/one/G______/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/G______/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Rafael"

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III"

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III"

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The soccer team members"

--- a/tests/lib/cff_1_3_0/authors/one/__A____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Rafa"

--- a/tests/lib/cff_1_3_0/authors/one/___N___/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The soccer team members"

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "van der Vaart III, Rafael"

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "affiliation": "Netherlands eScience Center",

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "van der Vaart III, Rafael",

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "van der Vaart III, Rafael",

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "Rafael",

--- a/tests/lib/cff_1_3_0/contributors/one/G______/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "Rafael",

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "van der Vaart III",

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "van der Vaart III",

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "The soccer team members",

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "The soccer team members",

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test of author inputs",
+    "type": {
+      "id": "notes"
+    }
+  },
   "contributors": [
     {
       "name": "van der Vaart III, Rafael",

--- a/tests/lib/cff_1_3_0/identifiers/relation/.zenodo.json
+++ b/tests/lib/cff_1_3_0/identifiers/relation/.zenodo.json
@@ -1,16 +1,22 @@
 {
+  "additional_descriptions": {
+    "description": "Test for relation type",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
-      "name": "Test author"
+      "name": "The author name"
     }
   ],
   "related_identifiers": [
     {
-      "identifier": "10.0000/from-identifiers",
+      "identifier": "10.0000/some-identifier",
       "relation": "isCompiledBy",
       "scheme": "doi"
     }
   ],
-  "title": "Test title",
+  "title": "The title",
   "upload_type": "software"
 }

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/.zenodo.json
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/.zenodo.json
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/.zenodo.json
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing urls",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/.zenodo.json
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/.zenodo.json
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "test for constructing dois",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/types/dataset/.zenodo.json
+++ b/tests/lib/cff_1_3_0/types/dataset/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "The message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The name"

--- a/tests/lib/cff_1_3_0/types/none/.zenodo.json
+++ b/tests/lib/cff_1_3_0/types/none/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "The message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The name"

--- a/tests/lib/cff_1_3_0/types/software/.zenodo.json
+++ b/tests/lib/cff_1_3_0/types/software/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "The message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "The name"

--- a/tests/lib/cff_1_3_0/urls/IRACU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IRACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/IRAC_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/IRA_U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/IRA__/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IRA__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/IR_CU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/IR_C_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/IR__U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IR__U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/IR___/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/IR___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I_ACU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I_AC_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I_A_U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I_A__/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I_A__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I__CU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I__CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I__C_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I__C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I___U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I___U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/I____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/I____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_RACU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_RACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_RAC_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_RA_U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_RA__/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_RA__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_R_CU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_R_C_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_R__U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_R__U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_R___/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_R___/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/__ACU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/__ACU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/__AC_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/__AC_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/__A_U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/__A_U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/__A__/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/__A__/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/___CU/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/___CU/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/___C_/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/___C_/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/____U/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/____U/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"

--- a/tests/lib/cff_1_3_0/urls/_____/.zenodo.json
+++ b/tests/lib/cff_1_3_0/urls/_____/.zenodo.json
@@ -1,4 +1,10 @@
 {
+  "additional_descriptions": {
+    "description": "Test message",
+    "type": {
+      "id": "notes"
+    }
+  },
   "creators": [
     {
       "name": "Test author"


### PR DESCRIPTION
I notice that the `message` key in `CITATION.cff` isn't being translated to anything on the Zenodo side. 

The equivalent on Zenodo appears to be an `additional_description` with the type of  `notes`, which formats it in a box to tell the consumer how to use the citation, e.g.  https://zenodo.org/records/10648000

This PR implements this translation, turning:

``` yaml
- message: If you use this software, please cite it using these metadata.
```

into:

``` json
"additional_descriptions": {
    "description": "If you use this software, please cite it using these metadata.",
    "type": {
      "id": "notes"
    }
  },
```

This would again, be another step towards needing to maintain this message in two places.