### PR TITLE
Handle multiple affiliations in Zenodo for CFF 1.3.0+

### DIFF
--- a/src/cffconvert/lib/cff_1_3_x/authors/zenodo.py
+++ b/src/cffconvert/lib/cff_1_3_x/authors/zenodo.py
@@ -1,0 +1,120 @@
+from cffconvert.lib.cff_1_x_x.authors.zenodo import ZenodoAuthor
+
+def _get_id_from_ror_url(affiliation):
+    return affiliation.get("ror").replace("https://ror.org/", "")
+
+# transform the input json
+def _parse_affiliations(json_dict, affiliations):
+    # handle multiple affiliations, and output a list
+    if type(affiliations) == list:
+        new_affil = []
+        for affil in affiliations:
+            # only string
+            if type(affil) == str:
+                new_affil.append({'name': affil})
+            else:
+                # if 'ror' is present replace 'ror' with 'id' in the json
+                if 'ror' in affil:
+                    affil['id'] = _get_id_from_ror_url(affil)
+                    del affil['ror']
+                new_affil.append(affil)
+        json_dict["affiliations"] = new_affil
+    # otherwise default to handling it as plain string
+    elif type(affiliations) == str:
+        json_dict["affiliation"] = affiliations
+
+    return json_dict
+
+# pylint: disable=too-few-public-methods
+class ZenodoAuthorAffiliation(ZenodoAuthor):
+
+    def __init__(self, author):
+        super().__init__(author)
+
+    def _from_affiliation(self):
+        return _parse_affiliations({}, self._author.get("affiliation"))
+
+    def _from_affiliation_and_orcid(self):
+        return _parse_affiliations(
+            {
+                "affiliation": self._author.get("affiliation"),
+                "orcid": self._get_id_from_orcid_url()
+            },
+            self._author.get("affiliation"))
+
+    def _from_alias_and_affiliation(self):
+        return parse_affilations(
+            {
+                "name": self._author.get("alias")
+            },
+            self._author.get("affiliation"))
+
+    def _from_alias_and_affiliation_and_orcid(self):
+        return _parse_affiliations(
+            {
+                "name": self._author.get("alias"),
+                "orcid": self._get_id_from_orcid_url()
+            },
+            self._author.get("affiliation"))
+
+    def _from_given_and_affiliation(self):
+        return _parse_affiliations(
+            {
+                "name": self._author.get("given-names")
+            },
+            self._author.get("affiliation"))
+    
+    def _from_given_and_affiliation_and_orcid(self):
+        return _parse_affiliations(
+            {
+                "name": self._author.get("given-names"),
+                "orcid": self._get_id_from_orcid_url()
+            },
+            self._author.get("affiliation"))
+
+    def _from_given_and_last_and_affiliation(self):
+        return _parse_affiliations(
+            {
+                "name": self._get_full_last_name() + ", " + self._author.get("given-names")
+            },
+            self._author.get("affiliation"))
+    
+    def _from_given_and_last_and_affiliation_and_orcid(self):
+        return _parse_affiliations(
+            {
+            "name": self._get_full_last_name() + ", " + self._author.get("given-names"),
+            "orcid": self._get_id_from_orcid_url()
+            },
+            self._author.get("affiliation")
+        )
+
+    def _from_last_and_affiliation(self):
+        return _parse_affiliations(
+            {
+                "name": self._get_full_last_name()
+            },
+            self._author.get("affiliation"))
+    
+    def _from_last_and_affiliation_and_orcid(self):
+        return _parse_affiliations(
+            {
+                "name": self._get_full_last_name(),
+            "orcid": self._get_id_from_orcid_url()
+            },
+            self._author.get("affiliation"))
+    
+    def _from_name_and_affiliation(self):
+        return _parse_affiliations(
+            {
+            "name": self._author.get("name")
+            },
+            self._author.get("affiliation")
+        )
+
+    def _from_name_and_affiliation_and_orcid(self):
+        return _parse_affiliations(
+            {
+                "name": self._author.get("name"),
+                "orcid": self._get_id_from_orcid_url()
+            },
+            self._author.get("affiliation"))

--- a/src/cffconvert/lib/cff_1_3_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_3_x/zenodo.py
@@ -1,4 +1,3 @@
-#from cffconvert.lib.cff_1_x_x.authors.zenodo import ZenodoAuthor
 from cffconvert.lib.cff_1_3_x.authors.zenodo import ZenodoAuthorAffiliation
 from cffconvert.lib.cff_1_x_x.zenodo import ZenodoObjectShared as Shared
 

--- a/src/cffconvert/lib/cff_1_3_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_3_x/zenodo.py
@@ -1,4 +1,5 @@
-from cffconvert.lib.cff_1_x_x.authors.zenodo import ZenodoAuthor
+#from cffconvert.lib.cff_1_x_x.authors.zenodo import ZenodoAuthor
+from cffconvert.lib.cff_1_3_x.authors.zenodo import ZenodoAuthorAffiliation
 from cffconvert.lib.cff_1_x_x.zenodo import ZenodoObjectShared as Shared
 
 
@@ -13,7 +14,7 @@ class ZenodoObject(Shared):
         for c in self.cffobj.get("contributors", []):
             # contributors are generated in the same way as authors, hence just
             # call ZenodoAuthor's contructor with the cff contributor object
-            contributor = ZenodoAuthor(c).as_dict()
+            contributor = ZenodoAuthorAffiliation(c).as_dict()
             contributor.update({"type": "Other"})
             contributors.append(contributor)
         # filter out contributors that had no data associated with them
@@ -24,7 +25,7 @@ class ZenodoObject(Shared):
 
     def add_creators(self):
         authors_cff = self.cffobj.get("authors", [])
-        creators_zenodo = [ZenodoAuthor(a).as_dict() for a in authors_cff]
+        creators_zenodo = [ZenodoAuthorAffiliation(a).as_dict() for a in authors_cff]
         self.creators = [c for c in creators_zenodo if c is not None]
         return self
 

--- a/src/cffconvert/schemas/1.3.0/schema.json
+++ b/src/cffconvert/schemas/1.3.0/schema.json
@@ -4,6 +4,31 @@
             "$ref": "#/$defs/strictish-string",
             "description": "An address."
         },
+        "affiliation": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/strictish-string"
+                },
+                {
+                    "$ref": "#/$defs/entity"
+                },
+                {
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/strictish-string"
+                            },
+                            {
+                                "$ref": "#/$defs/entity"
+                            }
+                        ]
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": true
+                }
+            ]
+        },	
         "alias": {
             "$ref": "#/$defs/strictish-string",
             "description": "An alias."
@@ -304,7 +329,7 @@
                     "description": "The entity's address."
                 },
                 "affiliation": {
-                    "$ref": "#/$defs/strictish-string",
+                    "$ref": "#/$defs/affiliation",
                     "description": "The entity's affiliation."
                 },
                 "alias": {
@@ -1199,7 +1224,7 @@
                     "description": "The person's address."
                 },
                 "affiliation": {
-                    "$ref": "#/$defs/strictish-string",
+                    "$ref": "#/$defs/affiliation",
                     "description": "The person's affiliation."
                 },
                 "alias": {


### PR DESCRIPTION
This is an incomplete draft pull request to partially implement multiple affiliations once the upstream schema change is merged in to CFF v1.3.0 in https://github.com/citation-file-format/citation-file-format/pull/523

This PR:
* is missing unit tests for the moment
* overrides the base class in `cff_1_x_x/authors/zenodo` to create an   `affiliations:`  key in `.zenodo.json` if a list is present, otherwise defaults back to the `affiliation` key.
* uses the `ror` if present, but outputs it as `id` for Zenodo backend.